### PR TITLE
Refactor typography helpers and fix Section children rendering

### DIFF
--- a/components/Section.js
+++ b/components/Section.js
@@ -1,5 +1,13 @@
-const Section = ({ id, children }) => (
-  <section id={id} className="relative -top-15" />
+import cn from 'classnames'
+
+const Section = ({ id, className, children, ...props }) => (
+  <section
+    id={id}
+    className={cn('relative -top-15', className)}
+    {...props}
+  >
+    {children}
+  </section>
 )
 
 export default Section

--- a/components/tags.js
+++ b/components/tags.js
@@ -1,58 +1,22 @@
 import cn from 'classnames'
 
-export const H1 = ({ className, style, children, bold = true }) => (
-  <h1
-    className={cn(
-      'text-3xl text-center tablet:text-4xl',
-      { 'font-bold': bold },
-      className
-    )}
-    style={style}
-  >
-    {children}
-  </h1>
-)
+const createTextTag = (Tag, baseClasses, defaultBold = true) => {
+  const TextTag = ({ className, style, children, bold = defaultBold }) => (
+    <Tag
+      className={cn(baseClasses, { 'font-bold': bold }, className)}
+      style={style}
+    >
+      {children}
+    </Tag>
+  )
 
-export const H2 = ({ className, style, children, bold = true }) => (
-  <h2
-    className={cn(
-      'text-2xl text-center tablet:text-3xl',
-      { 'font-bold': bold },
-      className
-    )}
-    style={style}
-  >
-    {children}
-  </h2>
-)
+  TextTag.displayName = `TextTag(${typeof Tag === 'string' ? Tag.toUpperCase() : 'Custom'})`
 
-export const H3 = ({ className, style, children, bold = true }) => (
-  <h3
-    className={cn(
-      'text-lg text-center tablet:text-xl',
-      { 'font-bold': bold },
-      className
-    )}
-    style={style}
-  >
-    {children}
-  </h3>
-)
+  return TextTag
+}
 
-export const H4 = ({ className, style, children, bold = true }) => (
-  <h4
-    className={cn('text-lg text-center', { 'font-bold': bold }, className)}
-    style={style}
-  >
-    {children}
-  </h4>
-)
-
-export const P = ({ className, style, children, bold = false }) => (
-  <p
-    className={cn('text-base laptop:text-xl', { 'font-bold': bold }, className)}
-    style={style}
-  >
-    {children}
-  </p>
-)
+export const H1 = createTextTag('h1', 'text-3xl text-center tablet:text-4xl')
+export const H2 = createTextTag('h2', 'text-2xl text-center tablet:text-3xl')
+export const H3 = createTextTag('h3', 'text-lg text-center tablet:text-xl')
+export const H4 = createTextTag('h4', 'text-lg text-center')
+export const P = createTextTag('p', 'text-base laptop:text-xl', false)


### PR DESCRIPTION
## Summary
- allow the Section component to accept children and extra props for anchor sections
- refactor reusable text tag components to share a common factory for easier maintenance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b702df548329a8454caf0da4db6c