### PR TITLE
Reduce callback data size for finance menu

### DIFF
--- a/pages/[location]/control/[jsonCommand].js
+++ b/pages/[location]/control/[jsonCommand].js
@@ -8,6 +8,7 @@ import dbConnect from '@utils/dbConnect'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
+import { decodeCommandKeys } from 'telegram/func/commandShortcuts'
 
 const commands = [
   'setUserName',
@@ -125,8 +126,10 @@ const commands = [
   'setTaskCoordinateRadius',
   'archiveGamesEdit',
   'editGamePrices',
+  'editGameFinances',
   'editGamePrice',
   'addGamePrice',
+  'addGameFinance',
   'setGamePriceName',
   'setGamePricePrice',
   'setBonusForTaskComplite',
@@ -256,7 +259,7 @@ export const getServerSideProps = async (context) => {
 
   let cmd
   try {
-    cmd = JSON.parse(jsonCommand)
+    cmd = decodeCommandKeys(JSON.parse(jsonCommand))
   } catch (error) {
     cmd = { c: jsonCommand }
   }

--- a/schemas/gamesSchema.js
+++ b/schemas/gamesSchema.js
@@ -199,6 +199,18 @@ const gamesSchema = {
     type: [{ id: String, name: { type: String, trim: true }, price: Number }],
     default: [],
   },
+  finances: {
+    type: [
+      {
+        id: { type: String, trim: true },
+        type: { type: String, enum: ['income', 'expense'] },
+        sum: { type: Number, default: 0 },
+        date: { type: Date, default: null },
+        description: { type: String, trim: true, default: '' },
+      },
+    ],
+    default: [],
+  },
   showTasks: {
     type: Boolean,
     default: false,

--- a/telegram/commandHandler.js
+++ b/telegram/commandHandler.js
@@ -1,11 +1,12 @@
 import executeCommand from './func/executeCommand'
+import { decodeCommandKeys } from './func/commandShortcuts'
 import sendMessage from './sendMessage'
 
 function jsonParser(str) {
   try {
     if (!str) return
     const json = JSON.parse(str)
-    if (typeof json === 'object') return json
+    if (typeof json === 'object') return decodeCommandKeys(json)
     return
   } catch (e) {
     return

--- a/telegram/commands/addGameFinance.js
+++ b/telegram/commands/addGameFinance.js
@@ -1,0 +1,126 @@
+import arrayOfCommands from 'telegram/func/arrayOfCommands'
+import check from 'telegram/func/check'
+import moment from 'moment-timezone'
+import { v4 as uuidv4 } from 'uuid'
+
+const cancelButton = (jsonCommand) => ({
+  c: { c: 'editGameFinances', gameId: jsonCommand.gameId },
+  text: '\u{1F6AB} Отмена добавления транзакции',
+})
+
+const formatAmount = (value) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0'
+  }
+  return Number.isInteger(value) ? `${value}` : value.toFixed(2).replace('.', ',')
+}
+
+const parseAmount = (value) => {
+  const prepared = String(value).replace(/\s+/g, '').replace(',', '.')
+  const parsed = Number(prepared)
+  return Number.isFinite(parsed) ? parsed : NaN
+}
+
+const parseDate = (value) => {
+  const trimmed = String(value).trim()
+  const formats = ['DD.MM.YYYY', 'DD.MM.YY', 'DD.MM']
+  for (const format of formats) {
+    const date = moment(trimmed, format, true)
+    if (date.isValid()) {
+      if (format === 'DD.MM') {
+        const now = moment()
+        date.year(now.year())
+      }
+      if (format === 'DD.MM.YY') {
+        const year = date.year()
+        date.year(year < 100 ? 2000 + year : year)
+      }
+      return date.toDate()
+    }
+  }
+  return null
+}
+
+const array = [
+  {
+    prop: 'sum',
+    message: 'Введите сумму транзакции в рублях',
+    checkAnswer: (answer) => {
+      const value = parseAmount(answer)
+      return !Number.isNaN(value) && value > 0
+    },
+    errorMessage: () => 'Сумма должна быть положительным числом.',
+    answerMessage: (answer) => {
+      const value = parseAmount(answer)
+      return `Сумма: ${formatAmount(value)} руб.`
+    },
+    answerConverter: (answer) => parseAmount(answer),
+    buttons: (jsonCommand) => [cancelButton(jsonCommand)],
+  },
+  {
+    prop: 'date',
+    message: 'Введите дату транзакции в формате ДД.ММ.ГГГГ',
+    checkAnswer: (answer) => parseDate(answer) !== null,
+    errorMessage: () => 'Дата должна быть в формате ДД.ММ.ГГГГ.',
+    answerMessage: (answer) => {
+      const date = moment(parseDate(answer)).tz('Asia/Krasnoyarsk')
+      return `Дата: ${date.format('DD.MM.YYYY')}`
+    },
+    answerConverter: (answer) => parseDate(answer),
+    buttons: (jsonCommand) => [cancelButton(jsonCommand)],
+  },
+  {
+    prop: 'description',
+    message: 'Введите описание транзакции',
+    checkAnswer: (answer) => String(answer).trim().length > 0,
+    errorMessage: () => 'Описание не может быть пустым.',
+    answerMessage: (answer) => `Описание: ${String(answer).trim()}`,
+    answerConverter: (answer) => String(answer).trim(),
+    buttons: (jsonCommand) => [cancelButton(jsonCommand)],
+  },
+]
+
+const addGameFinance = async ({ telegramId, jsonCommand, location, db }) => {
+  const checkData = check(jsonCommand, ['gameId', 'financeType'])
+  if (checkData) return checkData
+
+  if (!['income', 'expense'].includes(jsonCommand.financeType)) {
+    return {
+      success: false,
+      message: 'Неизвестный тип транзакции.',
+      nextCommand: { c: 'editGameFinances', gameId: jsonCommand.gameId },
+    }
+  }
+
+  return await arrayOfCommands({
+    array,
+    jsonCommand,
+    onFinish: async (result) => {
+      const finance = {
+        id: uuidv4(),
+        type: jsonCommand.financeType,
+        sum: result.sum,
+        date: result.date,
+        description: result.description,
+      }
+
+      await db.model('Games').findByIdAndUpdate(jsonCommand.gameId, {
+        $push: { finances: finance },
+      })
+
+      const typeName =
+        jsonCommand.financeType === 'income' ? 'Доход' : 'Расход'
+
+      return {
+        success: true,
+        message: `${typeName} на сумму ${formatAmount(result.sum)} руб. добавлен.`,
+        nextCommand: {
+          c: 'editGameFinances',
+          gameId: jsonCommand.gameId,
+        },
+      }
+    },
+  })
+}
+
+export default addGameFinance

--- a/telegram/commands/commandsArray.js
+++ b/telegram/commands/commandsArray.js
@@ -131,6 +131,8 @@ import gameTeamCheckPhotosInTask from './gameTeamCheckPhotosInTask'
 import gamePhotos from './gamePhotos'
 import gameTeamPhotos from './gameTeamPhotos'
 import gameTeamPayments from './gameTeamPayments'
+import editGameFinances from './editGameFinances'
+import addGameFinance from './addGameFinance'
 import usersStatistics from './usersStatistics'
 import gameResultFormTeamsPlaces from './gameResultFormTeamsPlaces'
 import cancelTask from './cancelTask'
@@ -264,8 +266,10 @@ const commandsArray = {
   setTaskCoordinateRadius,
   archiveGamesEdit,
   editGamePrices,
+  editGameFinances,
   editGamePrice,
   addGamePrice,
+  addGameFinance,
   setGamePriceName,
   setGamePricePrice,
   setBonusForTaskComplite,

--- a/telegram/commands/editGame.js
+++ b/telegram/commands/editGame.js
@@ -192,6 +192,13 @@ const editGame = async ({ telegramId, jsonCommand, location, db }) => {
         },
         text: '\u{1F4B2} Варианты и цены участия',
       },
+      {
+        c: {
+          c: 'editGameFinances',
+          gameId: jsonCommand.gameId,
+        },
+        text: '\u{1F4B0} Финансы',
+      },
       [
         {
           c: { c: 'setGameStartingPlace', gameId: jsonCommand.gameId },

--- a/telegram/commands/editGameFinances.js
+++ b/telegram/commands/editGameFinances.js
@@ -1,0 +1,111 @@
+import check from 'telegram/func/check'
+import getGame from 'telegram/func/getGame'
+import moment from 'moment-timezone'
+
+const formatAmount = (value) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0'
+  }
+  return Number.isInteger(value) ? `${value}` : value.toFixed(2).replace('.', ',')
+}
+
+const formatDate = (value) => {
+  if (!value) return '[без даты]'
+  const date = moment(value)
+  if (!date.isValid()) {
+    return '[неверная дата]'
+  }
+  return date.tz('Asia/Krasnoyarsk').format('DD.MM.YYYY')
+}
+
+const editGameFinances = async ({ telegramId, jsonCommand, location, db }) => {
+  const checkData = check(jsonCommand, ['gameId'])
+  if (checkData) return checkData
+
+  const game = await getGame(jsonCommand.gameId, db)
+  if (game.success === false) return game
+
+  const finances = Array.isArray(game.finances) ? game.finances : []
+  const sortedFinances = [...finances].sort((a, b) => {
+    const dateA = a?.date ? new Date(a.date).getTime() : 0
+    const dateB = b?.date ? new Date(b.date).getTime() : 0
+    return dateB - dateA
+  })
+
+  const totalIncome = sortedFinances
+    .filter(({ type }) => type === 'income')
+    .reduce((acc, { sum }) => acc + (Number(sum) || 0), 0)
+  const totalExpense = sortedFinances
+    .filter(({ type }) => type === 'expense')
+    .reduce((acc, { sum }) => acc + (Number(sum) || 0), 0)
+  const balance = totalIncome - totalExpense
+
+  const pageFromCommandRaw = Number(jsonCommand?.page ?? 1)
+  const pageFromCommand = Number.isFinite(pageFromCommandRaw)
+    ? pageFromCommandRaw
+    : 1
+  const perPage = 10
+  const totalPages = Math.max(1, Math.ceil(sortedFinances.length / perPage))
+  const currentPage = Math.min(Math.max(pageFromCommand, 1), totalPages)
+  const startIndex = (currentPage - 1) * perPage
+  const visibleFinances = sortedFinances.slice(startIndex, startIndex + perPage)
+
+  const transactionsText =
+    visibleFinances.length > 0
+      ? visibleFinances
+          .map(({ date, type, sum, description }) => {
+            const sign = type === 'income' ? '\u2795' : '\u2796'
+            const typeName = type === 'income' ? 'Доход' : 'Расход'
+            const descriptionText = description ? ` — ${description}` : ''
+            return `${sign} ${formatDate(date)} · ${typeName}: ${formatAmount(
+              Number(sum) || 0
+            )} руб.${descriptionText}`
+          })
+          .join('\\n')
+      : 'Транзакций пока нет.'
+
+  const pageInfo =
+    totalPages > 1 ? `\\n\\nСтраница ${currentPage} из ${totalPages}` : ''
+
+  const buttons = []
+  const navigationRow = []
+  if (currentPage > 1) {
+    navigationRow.push({
+      c: { c: 'editGameFinances', gameId: jsonCommand.gameId, page: currentPage - 1 },
+      text: '\u2B05\uFE0F Назад',
+    })
+  }
+  if (currentPage < totalPages) {
+    navigationRow.push({
+      c: { c: 'editGameFinances', gameId: jsonCommand.gameId, page: currentPage + 1 },
+      text: 'Вперед \u27A1\uFE0F',
+    })
+  }
+  if (navigationRow.length > 0) {
+    buttons.push(navigationRow)
+  }
+
+  buttons.push([
+    {
+      c: { c: 'addGameFinance', gameId: jsonCommand.gameId, financeType: 'income' },
+      text: '\u2795 Добавить доход',
+    },
+    {
+      c: { c: 'addGameFinance', gameId: jsonCommand.gameId, financeType: 'expense' },
+      text: '\u2796 Добавить расход',
+    },
+  ])
+
+  buttons.push({ c: { c: 'editGame', gameId: jsonCommand.gameId }, text: '\u2B05 Назад' })
+
+  return {
+    message: `<b>Финансы игры "${game?.name}"</b>\\n\\n<b>Доходы</b>: ${formatAmount(
+      totalIncome
+    )} руб.\\n<b>Расходы</b>: ${formatAmount(totalExpense)} руб.\\n<b>Баланс</b>: ${formatAmount(
+      balance
+    )} руб.\\n\\n${transactionsText}${pageInfo}`,
+    buttons,
+  }
+}
+
+export default editGameFinances

--- a/telegram/func/commandShortcuts.js
+++ b/telegram/func/commandShortcuts.js
@@ -1,0 +1,37 @@
+const keyShortcuts = {
+  gameId: 'g',
+  page: 'p',
+  financeType: 'f',
+}
+
+export const encodeCommandKeys = (command) => {
+  if (!command || typeof command !== 'object') return {}
+
+  const encoded = {}
+
+  Object.entries(command).forEach(([key, value]) => {
+    if (key === 'c') return
+
+    const shortKey = keyShortcuts[key]
+    encoded[shortKey ?? key] = value
+  })
+
+  return encoded
+}
+
+export const decodeCommandKeys = (command) => {
+  if (!command || typeof command !== 'object') return command
+
+  const decoded = { ...command }
+
+  Object.entries(keyShortcuts).forEach(([key, shortKey]) => {
+    if (decoded[shortKey] !== undefined && decoded[key] === undefined) {
+      decoded[key] = decoded[shortKey]
+      delete decoded[shortKey]
+    }
+  })
+
+  return decoded
+}
+
+export default keyShortcuts

--- a/telegram/func/keyboardFormer.js
+++ b/telegram/func/keyboardFormer.js
@@ -1,4 +1,5 @@
 import { commandToNum } from 'telegram/commands/commandsArray'
+import { encodeCommandKeys } from './commandShortcuts'
 import inlineKeyboard from './inlineKeyboard'
 
 const buttonConstructor = ({ text, c, url }) => {
@@ -11,7 +12,10 @@ const buttonConstructor = ({ text, c, url }) => {
 
   // Значит команда в JSON формате
   if (c) {
-    const convertedCommand = { ...c, c: commandToNum[c.c] }
+    const convertedCommand = {
+      ...encodeCommandKeys(c),
+      c: commandToNum[c.c],
+    }
     return {
       text,
       callback_data: JSON.stringify(convertedCommand),


### PR DESCRIPTION
## Summary
- add shared helper to encode/decode common callback command keys for shorter payloads
- compress finance-related callback data when rendering keyboards and decode it when handling commands in the bot and control panel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b9ad29f88329ae59653ed1b9d9a1