### PR TITLE
Add period selection to admin finance statistics

### DIFF
--- a/pages/[location]/control/[jsonCommand].js
+++ b/pages/[location]/control/[jsonCommand].js
@@ -8,6 +8,7 @@ import dbConnect from '@utils/dbConnect'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
+import { decodeCommandKeys } from 'telegram/func/commandShortcuts'
 
 const commands = [
   'setUserName',
@@ -125,8 +126,10 @@ const commands = [
   'setTaskCoordinateRadius',
   'archiveGamesEdit',
   'editGamePrices',
+  'editGameFinances',
   'editGamePrice',
   'addGamePrice',
+  'addGameFinance',
   'setGamePriceName',
   'setGamePricePrice',
   'setBonusForTaskComplite',
@@ -256,7 +259,7 @@ export const getServerSideProps = async (context) => {
 
   let cmd
   try {
-    cmd = JSON.parse(jsonCommand)
+    cmd = decodeCommandKeys(JSON.parse(jsonCommand))
   } catch (error) {
     cmd = { c: jsonCommand }
   }

--- a/schemas/gamesSchema.js
+++ b/schemas/gamesSchema.js
@@ -199,6 +199,18 @@ const gamesSchema = {
     type: [{ id: String, name: { type: String, trim: true }, price: Number }],
     default: [],
   },
+  finances: {
+    type: [
+      {
+        id: { type: String, trim: true },
+        type: { type: String, enum: ['income', 'expense'] },
+        sum: { type: Number, default: 0 },
+        date: { type: Date, default: null },
+        description: { type: String, trim: true, default: '' },
+      },
+    ],
+    default: [],
+  },
   showTasks: {
     type: Boolean,
     default: false,

--- a/telegram/commandHandler.js
+++ b/telegram/commandHandler.js
@@ -1,11 +1,12 @@
 import executeCommand from './func/executeCommand'
+import { decodeCommandKeys } from './func/commandShortcuts'
 import sendMessage from './sendMessage'
 
 function jsonParser(str) {
   try {
     if (!str) return
     const json = JSON.parse(str)
-    if (typeof json === 'object') return json
+    if (typeof json === 'object') return decodeCommandKeys(json)
     return
   } catch (e) {
     return

--- a/telegram/commands/addGameFinance.js
+++ b/telegram/commands/addGameFinance.js
@@ -1,0 +1,126 @@
+import arrayOfCommands from 'telegram/func/arrayOfCommands'
+import check from 'telegram/func/check'
+import moment from 'moment-timezone'
+import { v4 as uuidv4 } from 'uuid'
+
+const cancelButton = (jsonCommand) => ({
+  c: { c: 'editGameFinances', gameId: jsonCommand.gameId },
+  text: '\u{1F6AB} Отмена добавления транзакции',
+})
+
+const formatAmount = (value) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0'
+  }
+  return Number.isInteger(value) ? `${value}` : value.toFixed(2).replace('.', ',')
+}
+
+const parseAmount = (value) => {
+  const prepared = String(value).replace(/\s+/g, '').replace(',', '.')
+  const parsed = Number(prepared)
+  return Number.isFinite(parsed) ? parsed : NaN
+}
+
+const parseDate = (value) => {
+  const trimmed = String(value).trim()
+  const formats = ['DD.MM.YYYY', 'DD.MM.YY', 'DD.MM']
+  for (const format of formats) {
+    const date = moment(trimmed, format, true)
+    if (date.isValid()) {
+      if (format === 'DD.MM') {
+        const now = moment()
+        date.year(now.year())
+      }
+      if (format === 'DD.MM.YY') {
+        const year = date.year()
+        date.year(year < 100 ? 2000 + year : year)
+      }
+      return date.toDate()
+    }
+  }
+  return null
+}
+
+const array = [
+  {
+    prop: 'sum',
+    message: 'Введите сумму транзакции в рублях',
+    checkAnswer: (answer) => {
+      const value = parseAmount(answer)
+      return !Number.isNaN(value) && value > 0
+    },
+    errorMessage: () => 'Сумма должна быть положительным числом.',
+    answerMessage: (answer) => {
+      const value = parseAmount(answer)
+      return `Сумма: ${formatAmount(value)} руб.`
+    },
+    answerConverter: (answer) => parseAmount(answer),
+    buttons: (jsonCommand) => [cancelButton(jsonCommand)],
+  },
+  {
+    prop: 'date',
+    message: 'Введите дату транзакции в формате ДД.ММ.ГГГГ',
+    checkAnswer: (answer) => parseDate(answer) !== null,
+    errorMessage: () => 'Дата должна быть в формате ДД.ММ.ГГГГ.',
+    answerMessage: (answer) => {
+      const date = moment(parseDate(answer)).tz('Asia/Krasnoyarsk')
+      return `Дата: ${date.format('DD.MM.YYYY')}`
+    },
+    answerConverter: (answer) => parseDate(answer),
+    buttons: (jsonCommand) => [cancelButton(jsonCommand)],
+  },
+  {
+    prop: 'description',
+    message: 'Введите описание транзакции',
+    checkAnswer: (answer) => String(answer).trim().length > 0,
+    errorMessage: () => 'Описание не может быть пустым.',
+    answerMessage: (answer) => `Описание: ${String(answer).trim()}`,
+    answerConverter: (answer) => String(answer).trim(),
+    buttons: (jsonCommand) => [cancelButton(jsonCommand)],
+  },
+]
+
+const addGameFinance = async ({ telegramId, jsonCommand, location, db }) => {
+  const checkData = check(jsonCommand, ['gameId', 'financeType'])
+  if (checkData) return checkData
+
+  if (!['income', 'expense'].includes(jsonCommand.financeType)) {
+    return {
+      success: false,
+      message: 'Неизвестный тип транзакции.',
+      nextCommand: { c: 'editGameFinances', gameId: jsonCommand.gameId },
+    }
+  }
+
+  return await arrayOfCommands({
+    array,
+    jsonCommand,
+    onFinish: async (result) => {
+      const finance = {
+        id: uuidv4(),
+        type: jsonCommand.financeType,
+        sum: result.sum,
+        date: result.date,
+        description: result.description,
+      }
+
+      await db.model('Games').findByIdAndUpdate(jsonCommand.gameId, {
+        $push: { finances: finance },
+      })
+
+      const typeName =
+        jsonCommand.financeType === 'income' ? 'Доход' : 'Расход'
+
+      return {
+        success: true,
+        message: `${typeName} на сумму ${formatAmount(result.sum)} руб. добавлен.`,
+        nextCommand: {
+          c: 'editGameFinances',
+          gameId: jsonCommand.gameId,
+        },
+      }
+    },
+  })
+}
+
+export default addGameFinance

--- a/telegram/commands/adminFinanceStatistics.js
+++ b/telegram/commands/adminFinanceStatistics.js
@@ -1,0 +1,399 @@
+import moment from 'moment-timezone'
+import isUserAdmin from '@helpers/isUserAdmin'
+import { joinLines, joinSections } from 'telegram/func/messageFormatting'
+
+const TIMEZONE = 'Asia/Krasnoyarsk'
+const MONTHS = [
+  'Январь',
+  'Февраль',
+  'Март',
+  'Апрель',
+  'Май',
+  'Июнь',
+  'Июль',
+  'Август',
+  'Сентябрь',
+  'Октябрь',
+  'Ноябрь',
+  'Декабрь',
+]
+const INDENT = '&nbsp;&nbsp;'
+
+const formatAmount = (value) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0'
+  }
+  return Number.isInteger(value) ? `${value}` : value.toFixed(2).replace('.', ',')
+}
+
+const formatCurrency = (value) => `${formatAmount(value)} руб.`
+
+const chunkButtons = (buttons, size = 3) => {
+  const result = []
+  let chunk = []
+
+  buttons.forEach((button) => {
+    chunk.push(button)
+    if (chunk.length === size) {
+      result.push(chunk)
+      chunk = []
+    }
+  })
+
+  if (chunk.length > 0) {
+    result.push(chunk)
+  }
+
+  return result
+}
+
+const buildCommand = (state, overrides = {}) => {
+  const command = { c: 'adminFinanceStatistics' }
+  const merged = {
+    startYear: state.startYear,
+    startMonth: state.startMonth,
+    endYear: state.endYear,
+    endMonth: state.endMonth,
+    ...overrides,
+  }
+
+  Object.entries(merged).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      command[key] = value
+    }
+  })
+
+  return command
+}
+
+const buildYearSelection = ({
+  headerTitle,
+  prompt,
+  years,
+  state,
+  overrideKey,
+  filter = () => true,
+}) => {
+  const headerLines = ['<b>Финансовая статистика</b>', headerTitle]
+  const messageSections = [joinLines(headerLines), joinLines([prompt])]
+
+  const buttons = chunkButtons(
+    years
+      .filter(filter)
+      .map((year) => ({
+        text: `${year}`,
+        c: buildCommand(state, { [overrideKey]: year }),
+      })),
+    3
+  )
+
+  buttons.push([{ c: 'adminMenu', text: '\u{2B05} Назад' }])
+
+  return {
+    message: joinSections(messageSections),
+    buttons,
+  }
+}
+
+const buildMonthSelection = ({
+  headerTitle,
+  prompt,
+  state,
+  overrideKey,
+  allowedMonths,
+}) => {
+  const headerLines = ['<b>Финансовая статистика</b>', headerTitle]
+  const messageSections = [
+    joinLines(headerLines),
+    joinLines([prompt]),
+  ]
+
+  const buttons = chunkButtons(
+    allowedMonths.map((month) => ({
+      text: `${MONTHS[month - 1]}`,
+      c: buildCommand(state, { [overrideKey]: month }),
+    })),
+    3
+  )
+
+  buttons.push([{ c: 'adminMenu', text: '\u{2B05} Назад' }])
+
+  return {
+    message: joinSections(messageSections),
+    buttons,
+  }
+}
+
+const formatGameDate = (game) => {
+  const date = game?.dateStart || game?.dateStartFact || game?.dateEndFact
+  if (!date) {
+    return 'Без даты'
+  }
+  return moment(date).tz(TIMEZONE).format('DD.MM.YYYY')
+}
+
+const adminFinanceStatistics = async ({ user, db, jsonCommand = {} }) => {
+  if (!isUserAdmin(user)) {
+    return {
+      success: false,
+      message: 'Недостаточно прав для просмотра финансовой статистики.',
+    }
+  }
+
+  const state = {
+    startYear:
+      jsonCommand.startYear !== undefined ? Number(jsonCommand.startYear) : undefined,
+    startMonth:
+      jsonCommand.startMonth !== undefined
+        ? Number(jsonCommand.startMonth)
+        : undefined,
+    endYear:
+      jsonCommand.endYear !== undefined ? Number(jsonCommand.endYear) : undefined,
+    endMonth:
+      jsonCommand.endMonth !== undefined ? Number(jsonCommand.endMonth) : undefined,
+  }
+
+  const games = await db
+    .model('Games')
+    .find({})
+    .select({ _id: 1, name: 1, finances: 1, dateStart: 1, dateStartFact: 1, dateEndFact: 1 })
+    .lean()
+
+  if (!games || games.length === 0) {
+    const messageSections = [
+      joinLines(['<b>Финансовая статистика</b>', 'Игры отсутствуют.']),
+    ]
+
+    return {
+      message: joinSections(messageSections),
+      buttons: [{ c: 'adminMenu', text: '\u{2B05} Назад' }],
+    }
+  }
+
+  const gameIds = games.map((game) => String(game._id))
+
+  const payments = await db
+    .model('UsersGamesPayments')
+    .find({ gameId: { $in: gameIds } })
+    .lean()
+
+  const allDates = []
+
+  payments.forEach((payment) => {
+    if (payment?.createdAt) {
+      allDates.push(moment(payment.createdAt))
+    }
+  })
+
+  games.forEach((game) => {
+    const finances = Array.isArray(game.finances) ? game.finances : []
+    finances.forEach((finance) => {
+      if (finance?.date) {
+        allDates.push(moment(finance.date))
+      }
+    })
+  })
+
+  const now = moment().tz(TIMEZONE)
+  const years = allDates.length
+    ? Array.from(new Set(allDates.map((date) => date.tz(TIMEZONE).year()))).sort(
+        (a, b) => a - b
+      )
+    : [now.year()]
+
+  const minYear = years[0]
+  const maxYear = years[years.length - 1]
+
+  if (!state.startYear) {
+    return buildYearSelection({
+      headerTitle: 'Выбор периода',
+      prompt: 'С какого года нужна статистика?',
+      years,
+      state,
+      overrideKey: 'startYear',
+    })
+  }
+
+  const clampedStartYear = Math.min(Math.max(state.startYear, minYear), maxYear)
+  if (clampedStartYear !== state.startYear) {
+    state.startYear = clampedStartYear
+  }
+
+  if (!state.startMonth) {
+    return buildMonthSelection({
+      headerTitle: 'Выбор периода',
+      prompt: `Выбранный год начала: ${state.startYear}. Выберите месяц начала.`,
+      state,
+      overrideKey: 'startMonth',
+      allowedMonths: Array.from({ length: 12 }, (_, index) => index + 1),
+    })
+  }
+
+  if (!state.endYear) {
+    return buildYearSelection({
+      headerTitle: 'Выбор периода',
+      prompt: 'До какого года нужна статистика?',
+      years,
+      state,
+      overrideKey: 'endYear',
+      filter: (year) => year >= state.startYear,
+    })
+  }
+
+  const clampedEndYear = Math.min(Math.max(state.endYear, state.startYear), maxYear)
+  if (clampedEndYear !== state.endYear) {
+    state.endYear = clampedEndYear
+  }
+
+  if (!state.endMonth) {
+    const months = Array.from({ length: 12 }, (_, index) => index + 1).filter((month) => {
+      if (state.endYear === state.startYear) {
+        return month >= state.startMonth
+      }
+      return true
+    })
+
+    return buildMonthSelection({
+      headerTitle: 'Выбор периода',
+      prompt: `Выбранный год окончания: ${state.endYear}. Выберите месяц окончания.`,
+      state,
+      overrideKey: 'endMonth',
+      allowedMonths: months,
+    })
+  }
+
+  const startMoment = moment
+    .tz({ year: state.startYear, month: state.startMonth - 1 }, TIMEZONE)
+    .startOf('month')
+  const endMoment = moment
+    .tz({ year: state.endYear, month: state.endMonth - 1 }, TIMEZONE)
+    .endOf('month')
+
+  if (endMoment.isBefore(startMoment)) {
+    return buildMonthSelection({
+      headerTitle: 'Выбор периода',
+      prompt: `Выбранный год окончания: ${state.endYear}. Выберите месяц окончания.`,
+      state: { ...state, endMonth: undefined },
+      overrideKey: 'endMonth',
+      allowedMonths: Array.from({ length: 12 }, (_, index) => index + 1).filter((month) => {
+        if (state.endYear === state.startYear) {
+          return month >= state.startMonth
+        }
+        return true
+      }),
+    })
+  }
+
+  const paymentsByGame = payments.reduce((acc, payment) => {
+    const paymentGameId = String(payment?.gameId ?? '')
+    if (!paymentGameId) return acc
+    const sum = Number(payment?.sum) || 0
+    const createdAt = payment?.createdAt ? moment(payment.createdAt).tz(TIMEZONE) : null
+    if (!createdAt) return acc
+    if (createdAt.isBefore(startMoment) || createdAt.isAfter(endMoment)) {
+      return acc
+    }
+    acc[paymentGameId] = (acc[paymentGameId] || 0) + sum
+    return acc
+  }, {})
+
+  const statistics = games
+    .map((game) => {
+      const finances = Array.isArray(game.finances) ? game.finances : []
+
+      const otherIncome = finances
+        .filter(({ type }) => type === 'income')
+        .reduce((acc, { sum, date }) => {
+          if (!date) return acc
+          const financeDate = moment(date).tz(TIMEZONE)
+          if (financeDate.isBefore(startMoment) || financeDate.isAfter(endMoment)) {
+            return acc
+          }
+          return acc + (Number(sum) || 0)
+        }, 0)
+
+      const expenses = finances
+        .filter(({ type }) => type === 'expense')
+        .reduce((acc, { sum, date }) => {
+          if (!date) return acc
+          const financeDate = moment(date).tz(TIMEZONE)
+          if (financeDate.isBefore(startMoment) || financeDate.isAfter(endMoment)) {
+            return acc
+          }
+          return acc + (Number(sum) || 0)
+        }, 0)
+
+      const playerIncome = paymentsByGame[String(game._id)] || 0
+
+      const total = playerIncome + otherIncome - expenses
+
+      return {
+        name: game.name || 'Без названия',
+        date: formatGameDate(game),
+        playerIncome,
+        otherIncome,
+        expenses,
+        total,
+      }
+    })
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  const totals = statistics.reduce(
+    (acc, item) => {
+      acc.playerIncome += item.playerIncome
+      acc.otherIncome += item.otherIncome
+      acc.expenses += item.expenses
+      acc.total += item.total
+      return acc
+    },
+    { playerIncome: 0, otherIncome: 0, expenses: 0, total: 0 }
+  )
+
+  const startPeriodText = startMoment.format('MM.YYYY')
+  const endPeriodText = endMoment.format('MM.YYYY')
+
+  const headerLines = [
+    '<b>Финансовая статистика</b>',
+    `<b>Период:</b> ${startPeriodText} – ${endPeriodText}`,
+  ]
+
+  const messageSections = [joinLines(headerLines)]
+
+  statistics.forEach(({ name, date, playerIncome, otherIncome, expenses, total }) => {
+    const gameLines = [
+      `<b>${name}, ${date}</b>`,
+      `${INDENT}\u{2795}\u{1F465} Поступления от игроков: ${formatCurrency(
+        playerIncome
+      )}`,
+      `${INDENT}\u{2795} Прочие поступления: ${formatCurrency(otherIncome)}`,
+      `${INDENT}\u{2796} Расходы: ${formatCurrency(expenses)}`,
+      `${INDENT}\u{1F4B0} <b>Итого: ${formatCurrency(total)}</b>`,
+    ]
+
+    messageSections.push(joinLines(gameLines))
+  })
+
+  const totalsLines = [
+    '<b>ИТОГО ПО ПЕРИОДУ</b>',
+    `${INDENT}\u{2795}\u{1F465} Поступления от игроков: ${formatCurrency(
+      totals.playerIncome
+    )}`,
+    `${INDENT}\u{2795} Прочие поступления: ${formatCurrency(totals.otherIncome)}`,
+    `${INDENT}\u{2796} Расходы: ${formatCurrency(totals.expenses)}`,
+    `${INDENT}\u{1F4B0} <b>Итого: ${formatCurrency(totals.total)}</b>`,
+  ]
+
+  messageSections.push(joinLines(totalsLines))
+
+  const buttons = [
+    { text: '\u{1F4C5} Выбрать другой период', c: { c: 'adminFinanceStatistics' } },
+    { c: 'adminMenu', text: '\u{2B05} Назад' },
+  ]
+
+  return {
+    message: joinSections(messageSections),
+    buttons,
+  }
+}
+
+export default adminFinanceStatistics

--- a/telegram/commands/adminMenu.js
+++ b/telegram/commands/adminMenu.js
@@ -28,6 +28,11 @@ const adminMenu = async ({ telegramId, user }) => {
         hide: !isAdmin,
       },
       {
+        c: 'adminFinanceStatistics',
+        text: '\u{1F4B0} Финансовая статистика',
+        hide: !isAdmin,
+      },
+      {
         c: 'sendMessageToAll',
         text: '\u{1F4E2} Отправить сообщение всем пользователям',
         hide: !isAdmin,

--- a/telegram/commands/commandsArray.js
+++ b/telegram/commands/commandsArray.js
@@ -85,6 +85,7 @@ import setGameFinishingPlace from './setGameFinishingPlace'
 import setGameStartingPlace from './setGameStartingPlace'
 import allUsers from './allUsers'
 import adminMenu from './adminMenu'
+import adminFinanceStatistics from './adminFinanceStatistics'
 import gameResultShow from './gameResultShow'
 import gameResultHide from './gameResultHide'
 import checkGameTeamsDoubles from './checkGameTeamsDoubles'
@@ -131,6 +132,8 @@ import gameTeamCheckPhotosInTask from './gameTeamCheckPhotosInTask'
 import gamePhotos from './gamePhotos'
 import gameTeamPhotos from './gameTeamPhotos'
 import gameTeamPayments from './gameTeamPayments'
+import editGameFinances from './editGameFinances'
+import addGameFinance from './addGameFinance'
 import usersStatistics from './usersStatistics'
 import gameResultFormTeamsPlaces from './gameResultFormTeamsPlaces'
 import cancelTask from './cancelTask'
@@ -236,6 +239,7 @@ const commandsArray = {
   setGameStartingPlace,
   allUsers,
   adminMenu,
+  adminFinanceStatistics,
   delTeamUserAdmin2,
   gameResultShow,
   gameResultHide,
@@ -264,8 +268,10 @@ const commandsArray = {
   setTaskCoordinateRadius,
   archiveGamesEdit,
   editGamePrices,
+  editGameFinances,
   editGamePrice,
   addGamePrice,
+  addGameFinance,
   setGamePriceName,
   setGamePricePrice,
   setBonusForTaskComplite,

--- a/telegram/commands/editGame.js
+++ b/telegram/commands/editGame.js
@@ -192,6 +192,13 @@ const editGame = async ({ telegramId, jsonCommand, location, db }) => {
         },
         text: '\u{1F4B2} Варианты и цены участия',
       },
+      {
+        c: {
+          c: 'editGameFinances',
+          gameId: jsonCommand.gameId,
+        },
+        text: '\u{1F4B0} Финансы',
+      },
       [
         {
           c: { c: 'setGameStartingPlace', gameId: jsonCommand.gameId },

--- a/telegram/commands/editGameFinances.js
+++ b/telegram/commands/editGameFinances.js
@@ -1,0 +1,121 @@
+import check from 'telegram/func/check'
+import getGame from 'telegram/func/getGame'
+import moment from 'moment-timezone'
+import { joinLines, joinSections, newline } from 'telegram/func/messageFormatting'
+
+const formatAmount = (value) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0'
+  }
+  return Number.isInteger(value) ? `${value}` : value.toFixed(2).replace('.', ',')
+}
+
+const formatDate = (value) => {
+  if (!value) return '[без даты]'
+  const date = moment(value)
+  if (!date.isValid()) {
+    return '[неверная дата]'
+  }
+  return date.tz('Asia/Krasnoyarsk').format('DD.MM.YYYY')
+}
+
+const editGameFinances = async ({ telegramId, jsonCommand, location, db }) => {
+  const checkData = check(jsonCommand, ['gameId'])
+  if (checkData) return checkData
+
+  const game = await getGame(jsonCommand.gameId, db)
+  if (game.success === false) return game
+
+  const finances = Array.isArray(game.finances) ? game.finances : []
+  const sortedFinances = [...finances].sort((a, b) => {
+    const dateA = a?.date ? new Date(a.date).getTime() : 0
+    const dateB = b?.date ? new Date(b.date).getTime() : 0
+    return dateB - dateA
+  })
+
+  const totalIncome = sortedFinances
+    .filter(({ type }) => type === 'income')
+    .reduce((acc, { sum }) => acc + (Number(sum) || 0), 0)
+  const totalExpense = sortedFinances
+    .filter(({ type }) => type === 'expense')
+    .reduce((acc, { sum }) => acc + (Number(sum) || 0), 0)
+  const balance = totalIncome - totalExpense
+
+  const pageFromCommandRaw = Number(jsonCommand?.page ?? 1)
+  const pageFromCommand = Number.isFinite(pageFromCommandRaw)
+    ? pageFromCommandRaw
+    : 1
+  const perPage = 10
+  const totalPages = Math.max(1, Math.ceil(sortedFinances.length / perPage))
+  const currentPage = Math.min(Math.max(pageFromCommand, 1), totalPages)
+  const startIndex = (currentPage - 1) * perPage
+  const visibleFinances = sortedFinances.slice(startIndex, startIndex + perPage)
+
+  const transactionsText =
+    visibleFinances.length > 0
+      ? visibleFinances
+          .map(({ date, type, sum, description }) => {
+            const sign = type === 'income' ? '➕' : '➖'
+            const typeName = type === 'income' ? 'Доход' : 'Расход'
+            const descriptionText = description ? ` — ${description}` : ''
+            return `${sign} ${formatDate(date)} · ${typeName}: ${formatAmount(
+              Number(sum) || 0
+            )} руб.${descriptionText}`
+          })
+          .join(newline)
+      : 'Транзакций пока нет.'
+
+  const paginationLines =
+    totalPages > 1 ? [`Страница ${currentPage} из ${totalPages}`] : []
+
+  const buttons = []
+  const navigationRow = []
+  if (currentPage > 1) {
+    navigationRow.push({
+      c: { c: 'editGameFinances', gameId: jsonCommand.gameId, page: currentPage - 1 },
+      text: '⬅️ Назад',
+    })
+  }
+  if (currentPage < totalPages) {
+    navigationRow.push({
+      c: { c: 'editGameFinances', gameId: jsonCommand.gameId, page: currentPage + 1 },
+      text: 'Вперед ➡️',
+    })
+  }
+  if (navigationRow.length > 0) {
+    buttons.push(navigationRow)
+  }
+
+  buttons.push([
+    {
+      c: { c: 'addGameFinance', gameId: jsonCommand.gameId, financeType: 'income' },
+      text: '➕ Добавить доход',
+    },
+    {
+      c: { c: 'addGameFinance', gameId: jsonCommand.gameId, financeType: 'expense' },
+      text: '➖ Добавить расход',
+    },
+  ])
+
+  buttons.push({ c: { c: 'editGame', gameId: jsonCommand.gameId }, text: '⬅ Назад' })
+
+  const headerLines = [
+    `<b>Финансы игры "${game?.name}"</b>`,
+    `<b>Доходы</b>: ${formatAmount(totalIncome)} руб.`,
+    `<b>Расходы</b>: ${formatAmount(totalExpense)} руб.`,
+    `<b>Баланс</b>: ${formatAmount(balance)} руб.`,
+  ]
+
+  const messageSections = [
+    joinLines(headerLines),
+    joinLines([transactionsText]),
+    joinLines(paginationLines),
+  ]
+
+  return {
+    message: joinSections(messageSections),
+    buttons,
+  }
+}
+
+export default editGameFinances

--- a/telegram/commands/menuGamesEdit.js
+++ b/telegram/commands/menuGamesEdit.js
@@ -28,21 +28,27 @@ const menuGamesEdit = async ({ telegramId, jsonCommand, user, db }) => {
     })
   )
 
+  const messageSections = ['<b>Конструктор игр</b>']
+
+  if (!isAdmin) {
+    messageSections.push('В списке отображены только игры которые создали именно Вы')
+  }
+
+  const statisticsLine = `<b>Количество игр</b>: ${getNoun(
+    notArchiveGames.length,
+    'игра',
+    'игры',
+    'игр'
+  )}${
+    archiveGames?.length > 0
+      ? ` (в архиве ${getNoun(archiveGames.length, 'игра', 'игры', 'игр')})`
+      : ''
+  }`
+
+  messageSections.push(statisticsLine)
+
   return {
-    message: `<b>Конструктор игр</b>\n\n${
-      isAdmin
-        ? ''
-        : 'В списке отображены только игры которые создали именно Вы\n\n'
-    }<b>Количество игр</b>: ${getNoun(
-      notArchiveGames.length,
-      'игра',
-      'игры',
-      'игр'
-    )}${
-      archiveGames?.length > 0
-        ? ` (в архиве ${getNoun(archiveGames.length, 'игра', 'игры', 'игр')})`
-        : ''
-    }`,
+    message: messageSections.filter(Boolean).join('\n\n'),
     buttons: [
       ...buttons,
       ...(archiveGames?.length > 0

--- a/telegram/commands/menuUser.js
+++ b/telegram/commands/menuUser.js
@@ -6,9 +6,15 @@ const menuUser = async ({ telegramId, jsonCommand, location, db }) => {
     user = await db.model('Users').findOne({ telegramId })
   }
 
+  const message = user
+    ? `<b>Моя анкета</b>
+
+- <b>Имя</b>: ${user.name}`
+    : '<b>Моя анкета</b>'
+
   return {
     success: true,
-    message: `<b>Моя анкета</b>${user ? `:\n - <b>Имя</b>: ${user.name}` : ''}`,
+    message,
     buttonText: 'Команды',
     buttons: [
       { text: '\u{270F} Изменить имя', c: `setUserName` },

--- a/telegram/func/commandShortcuts.js
+++ b/telegram/func/commandShortcuts.js
@@ -1,0 +1,41 @@
+const keyShortcuts = {
+  gameId: 'g',
+  page: 'p',
+  financeType: 'f',
+  startYear: 'sy',
+  startMonth: 'sm',
+  endYear: 'ey',
+  endMonth: 'em',
+}
+
+export const encodeCommandKeys = (command) => {
+  if (!command || typeof command !== 'object') return {}
+
+  const encoded = {}
+
+  Object.entries(command).forEach(([key, value]) => {
+    if (key === 'c') return
+
+    const shortKey = keyShortcuts[key]
+    encoded[shortKey ?? key] = value
+  })
+
+  return encoded
+}
+
+export const decodeCommandKeys = (command) => {
+  if (!command || typeof command !== 'object') return command
+
+  const decoded = { ...command }
+
+  Object.entries(keyShortcuts).forEach(([key, shortKey]) => {
+    if (decoded[shortKey] !== undefined && decoded[key] === undefined) {
+      decoded[key] = decoded[shortKey]
+      delete decoded[shortKey]
+    }
+  })
+
+  return decoded
+}
+
+export default keyShortcuts

--- a/telegram/func/keyboardFormer.js
+++ b/telegram/func/keyboardFormer.js
@@ -1,4 +1,5 @@
 import { commandToNum } from 'telegram/commands/commandsArray'
+import { encodeCommandKeys } from './commandShortcuts'
 import inlineKeyboard from './inlineKeyboard'
 
 const buttonConstructor = ({ text, c, url }) => {
@@ -11,7 +12,10 @@ const buttonConstructor = ({ text, c, url }) => {
 
   // Значит команда в JSON формате
   if (c) {
-    const convertedCommand = { ...c, c: commandToNum[c.c] }
+    const convertedCommand = {
+      ...encodeCommandKeys(c),
+      c: commandToNum[c.c],
+    }
     return {
       text,
       callback_data: JSON.stringify(convertedCommand),

--- a/telegram/func/messageFormatting.js
+++ b/telegram/func/messageFormatting.js
@@ -1,0 +1,26 @@
+export const newline = '\n'
+export const doubleNewline = `${newline}${newline}`
+
+const isNonEmpty = (value) => {
+  if (value === null || value === undefined) {
+    return false
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0
+  }
+
+  return true
+}
+
+export const joinLines = (lines = []) => lines.filter(isNonEmpty).join(newline)
+
+export const joinSections = (sections = []) =>
+  sections.filter(isNonEmpty).join(doubleNewline)
+
+export default {
+  newline,
+  doubleNewline,
+  joinLines,
+  joinSections,
+}


### PR DESCRIPTION
## Summary
- add multi-step period selection for the admin finance statistics with year and month buttons
- filter player payments and manual finances by the chosen period and render the report with icon-based text formatting
- include a quick action to restart the period selection and compress callback payloads with new command shortcuts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b9ad29f88329ae59653ed1b9d9a1