### PR TITLE
Add web dashboard with Telegram authentication and redesign homepage

### DIFF
--- a/helpers/verifyTelegramAuthPayload.js
+++ b/helpers/verifyTelegramAuthPayload.js
@@ -1,0 +1,40 @@
+import crypto from 'crypto'
+
+const TELEGRAM_AUTH_TTL = 86400 // 24 hours
+
+const buildCheckString = (payload) =>
+  Object.keys(payload)
+    .sort()
+    .map((key) => `${key}=${payload[key]}`)
+    .join('\n')
+
+const verifyTelegramAuthPayload = (payload, botToken) => {
+  if (!payload || typeof payload !== 'object') return false
+  if (!botToken) return false
+
+  const { hash, auth_date: authDate, ...rest } = payload
+
+  if (!hash || !authDate) return false
+
+  const authDateNum = Number(authDate)
+  if (!Number.isFinite(authDateNum)) return false
+
+  const now = Math.floor(Date.now() / 1000)
+  if (Math.abs(now - authDateNum) > TELEGRAM_AUTH_TTL) return false
+
+  const secretKey = crypto
+    .createHash('sha256')
+    .update(botToken)
+    .digest()
+
+  const checkString = buildCheckString(rest)
+
+  const calculatedHash = crypto
+    .createHmac('sha256', secretKey)
+    .update(checkString)
+    .digest('hex')
+
+  return calculatedHash === hash
+}
+
+export default verifyTelegramAuthPayload

--- a/pages/api/webapp/command.js
+++ b/pages/api/webapp/command.js
@@ -1,0 +1,159 @@
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '../auth/[...nextauth]'
+import dbConnect from '@utils/dbConnect'
+import executeCommand from '@server/executeCommand'
+import { decodeCommandKeys } from 'telegram/func/commandShortcuts'
+import { numToCommand } from 'telegram/commands/commandsArray'
+
+const parseCommandPayload = (command) => {
+  if (!command) return null
+
+  let parsed = command
+
+  if (typeof command === 'string') {
+    if (command.startsWith('/')) {
+      return { c: command.slice(1) }
+    }
+
+    try {
+      parsed = JSON.parse(command)
+    } catch (error) {
+      return { c: command }
+    }
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return null
+
+  const decoded = decodeCommandKeys(parsed)
+  const commandValue = decoded.c
+
+  if (typeof commandValue === 'number') {
+    decoded.c = numToCommand[commandValue] ?? commandValue
+  }
+
+  return decoded
+}
+
+const mergeWithLastCommand = (command, lastCommand) => {
+  if (!command) return null
+  if (!lastCommand) return command
+
+  const result = { ...command }
+
+  if (result.prevC && lastCommand.prevCommand) {
+    const { prevC, ...rest } = result
+    return { ...lastCommand.prevCommand, ...rest }
+  }
+
+  if (!result.c) {
+    return { ...lastCommand.command, ...result }
+  }
+
+  return result
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, error: 'Method not allowed' })
+  }
+
+  const session = await getServerSession(req, res, authOptions)
+
+  if (!session?.user?.telegramId) {
+    return res.status(401).json({ success: false, error: 'Необходимо войти через Telegram' })
+  }
+
+  const { location, command, message } = req.body || {}
+  const targetLocation = location || session.user.location
+
+  if (!targetLocation) {
+    return res
+      .status(400)
+      .json({ success: false, error: 'Не удалось определить игровую площадку' })
+  }
+
+  try {
+    const db = await dbConnect(targetLocation)
+    if (!db) {
+      return res
+        .status(400)
+        .json({ success: false, error: 'Указана неизвестная игровая площадка' })
+    }
+
+    const telegramId = session.user.telegramId
+
+    let user = await db.model('Users').findOne({ telegramId })
+
+    if (!user) {
+      const name = session.user?.name || session.user?.username || 'Участник'
+      user = await db.model('Users').create({
+        telegramId,
+        name,
+        username: session.user?.username ?? null,
+        photoUrl: session.user?.photoUrl ?? null,
+        languageCode: session.user?.languageCode ?? null,
+        isPremium: session.user?.isPremium ?? false,
+      })
+    } else {
+      const updates = {}
+      if (session.user?.name && session.user.name !== user.name) {
+        updates.name = session.user.name
+      }
+      if (session.user?.username && session.user.username !== user.username) {
+        updates.username = session.user.username
+      }
+      if (session.user?.photoUrl && session.user.photoUrl !== user.photoUrl) {
+        updates.photoUrl = session.user.photoUrl
+      }
+      if (session.user?.languageCode && session.user.languageCode !== user.languageCode) {
+        updates.languageCode = session.user.languageCode
+      }
+      if (typeof session.user?.isPremium === 'boolean' && session.user.isPremium !== user.isPremium) {
+        updates.isPremium = session.user.isPremium
+      }
+
+      if (Object.keys(updates).length > 0) {
+        user = await db
+          .model('Users')
+          .findOneAndUpdate({ telegramId }, { $set: updates }, { new: true })
+      }
+    }
+
+    const lastCommand = await db
+      .model('LastCommands')
+      .findOne({ userTelegramId: telegramId })
+      .lean()
+
+    let jsonCommand = mergeWithLastCommand(parseCommandPayload(command), lastCommand)
+
+    if (message) {
+      if (jsonCommand) {
+        jsonCommand = { ...jsonCommand, message }
+      } else if (lastCommand?.command) {
+        jsonCommand = { ...lastCommand.command, message }
+      } else {
+        return res.status(400).json({ success: false, error: 'Команда для ответа не найдена' })
+      }
+    }
+
+    if (!jsonCommand) {
+      return res
+        .status(400)
+        .json({ success: false, error: 'Не удалось определить команду для выполнения' })
+    }
+
+    const result = await executeCommand({
+      userTelegramId: telegramId,
+      jsonCommand,
+      location: targetLocation,
+      user: user?.toObject ? user.toObject() : user,
+      db,
+      lastCommand,
+    })
+
+    return res.status(200).json({ success: true, result })
+  } catch (error) {
+    console.error('Web command error', error)
+    return res.status(500).json({ success: false, error: 'Не удалось выполнить команду' })
+  }
+}

--- a/pages/cabinet/index.js
+++ b/pages/cabinet/index.js
@@ -1,0 +1,389 @@
+import { useEffect, useMemo, useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import { signIn, signOut, useSession } from 'next-auth/react'
+import { TLoginButton, TLoginButtonSize } from 'react-telegram-auth'
+import { LOCATIONS } from '@server/serverConstants'
+import getTelegramBotNameByLocation from '@utils/telegram/getTelegramBotNameByLocation'
+
+const availableLocations = Object.entries(LOCATIONS)
+  .filter(([, value]) => !value.hidden)
+  .map(([key, value]) => ({ key, ...value }))
+
+const defaultLocation = availableLocations[0]?.key ?? 'dev'
+
+const formatText = (text) =>
+  (text || '')
+    .split('\n')
+    .map((part) => part.trim())
+    .join('\n')
+
+const BotMessage = ({ text }) => {
+  if (!text) return null
+
+  return (
+    <div
+      className="rounded-2xl bg-white p-4 shadow-sm"
+      dangerouslySetInnerHTML={{ __html: formatText(text).replaceAll('\n', '<br />') }}
+    />
+  )
+}
+
+const ConversationEntry = ({ entry }) => {
+  if (entry.type === 'user') {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-xl rounded-2xl bg-blue-500 px-4 py-2 text-sm font-medium text-white shadow-sm">
+          {entry.text}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-3xl space-y-2">
+        <BotMessage text={entry.text} />
+        {entry.keyboard?.length ? (
+          <div className="flex flex-col gap-2">
+            {entry.keyboard.map((row, rowIndex) => (
+              <div key={`row-${rowIndex}`} className="flex flex-wrap gap-2">
+                {row.map((button) => {
+                  if (button.url) {
+                    return (
+                      <a
+                        key={button.url}
+                        href={button.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex-1 rounded-xl border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-700 transition hover:bg-blue-100"
+                      >
+                        {button.text}
+                      </a>
+                    )
+                  }
+
+                  return (
+                    <button
+                      key={button.callback_data || button.text}
+                      className="flex-1 rounded-xl border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-700 transition hover:bg-blue-100"
+                      onClick={() => entry.onAction?.(button)}
+                      type="button"
+                    >
+                      {button.text}
+                    </button>
+                  )
+                })}
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+const CabinetPage = () => {
+  const { data: session, status } = useSession()
+  const [location, setLocation] = useState(() => session?.user?.location ?? defaultLocation)
+  const [input, setInput] = useState('')
+  const [history, setHistory] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [hasSyncedLocation, setHasSyncedLocation] = useState(false)
+  const [isClient, setIsClient] = useState(false)
+
+  const botName = useMemo(() => getTelegramBotNameByLocation(location), [location])
+
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
+  useEffect(() => {
+    if (session?.user?.location && !hasSyncedLocation) {
+      setLocation(session.user.location)
+      setHasSyncedLocation(true)
+    }
+
+    if (!session && hasSyncedLocation) {
+      setHasSyncedLocation(false)
+      setLocation(defaultLocation)
+    }
+  }, [session, hasSyncedLocation])
+
+  useEffect(() => {
+    if (session && status === 'authenticated') {
+      loadMainMenu(true)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session, location])
+
+  const appendEntry = (entry) => {
+    setHistory((prev) => [...prev, entry])
+  }
+
+  const loadMainMenu = async (resetHistory = false) => {
+    if (resetHistory) {
+      setHistory([])
+    }
+
+    await sendCommand({
+      command: 'mainMenu',
+      meta: 'Главное меню',
+      skipUserEcho: true,
+    })
+  }
+
+  const sendCommand = async ({ command, message, meta, skipUserEcho } = {}) => {
+    if (!session) return
+
+    if (!skipUserEcho && (meta || message)) {
+      appendEntry({ type: 'user', text: meta || message })
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/webapp/command', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ location, command, message }),
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null)
+        throw new Error(data?.error || 'Не удалось выполнить команду')
+      }
+
+      const data = await response.json()
+
+      if (!data.success) {
+        throw new Error(data.error || 'Не удалось выполнить команду')
+      }
+
+      const keyboard = data.result?.keyboard?.inline_keyboard || []
+
+      appendEntry({
+        type: 'bot',
+        text: data.result?.text,
+        keyboard,
+        onAction: (button) =>
+          sendCommand({
+            command: button.callback_data,
+            meta: button.text,
+          }),
+      })
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    if (!input.trim()) return
+
+    const value = input.trim()
+    const isCommand = value.startsWith('/')
+
+    sendCommand({
+      command: isCommand ? value : undefined,
+      message: isCommand ? undefined : value,
+      meta: value,
+    })
+
+    setInput('')
+  }
+
+  const handleTelegramAuth = (userData) => {
+    if (!userData) return
+
+    signIn('telegram', {
+      data: JSON.stringify(userData),
+      location,
+      redirect: false,
+    }).then((response) => {
+      if (response?.error) {
+        setError('Не удалось авторизоваться. Попробуйте ещё раз.')
+      } else {
+        setError(null)
+      }
+    })
+  }
+
+  const renderLogin = () => (
+    <div className="mx-auto mt-12 max-w-4xl rounded-3xl bg-white p-8 shadow-lg">
+      <h2 className="text-2xl font-bold text-primary">Войти через Telegram</h2>
+      <p className="mt-3 text-gray-600">
+        Выберите игровой регион и подтвердите вход через официальный виджет Telegram. Все данные
+        синхронизируются с ботом, поэтому вы сразу продолжите работу с квестами, командами и играми.
+      </p>
+      <div className="mt-6 flex flex-col gap-6">
+        <label className="flex flex-col gap-2 text-sm font-medium text-gray-700">
+          Регион
+          <select
+            className="rounded-xl border border-gray-200 px-4 py-3 text-base shadow-sm focus:border-blue-400 focus:outline-none focus:ring"
+            value={location}
+            onChange={(event) => setLocation(event.target.value)}
+          >
+            {availableLocations.map((item) => (
+              <option key={item.key} value={item.key}>
+                {item.townRu[0].toUpperCase() + item.townRu.slice(1)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="flex flex-col items-start gap-4">
+          {botName && isClient ? (
+            <TLoginButton
+              botName={botName}
+              buttonSize={TLoginButtonSize.Large}
+              lang="ru"
+              cornerRadius={16}
+              usePic
+              requestAccess="write"
+              onAuthCallback={handleTelegramAuth}
+            />
+          ) : (
+            <div className="rounded-2xl border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-gray-500">
+              Укажите название бота для региона в переменной окружения{' '}
+              <code className="rounded bg-gray-200 px-1">NEXT_PUBLIC_TELEGRAM_{location.toUpperCase()}_BOT_NAME</code>
+            </div>
+          )}
+          <p className="text-sm text-gray-500">
+            Нажимая кнопку входа, вы разрешаете ActQuest использовать данные вашей Telegram учетной записи
+            для авторизации и работы с ботом.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+
+  const renderDashboard = () => (
+    <div className="mx-auto mt-10 flex w-full max-w-6xl flex-col gap-8">
+      <div className="flex flex-col justify-between gap-4 rounded-3xl bg-gradient-to-r from-blue-600 to-purple-600 p-6 text-white shadow-lg lg:flex-row lg:items-center">
+        <div>
+          <h2 className="text-2xl font-semibold">
+            {session?.user?.name || session?.user?.username || 'Участник ActQuest'}
+          </h2>
+          <p className="mt-1 text-sm text-blue-100">
+            {LOCATIONS[location]?.townRu
+              ? `Регион: ${LOCATIONS[location].townRu[0].toUpperCase()}${LOCATIONS[location].townRu.slice(1)}`
+              : 'Регион не выбран'}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            className="rounded-xl border border-white/40 bg-white/20 px-4 py-2 text-sm font-semibold text-white outline-none transition hover:bg-white/30"
+            value={location}
+            onChange={(event) => setLocation(event.target.value)}
+          >
+            {availableLocations.map((item) => (
+              <option key={item.key} value={item.key} className="text-gray-900">
+                {item.townRu[0].toUpperCase() + item.townRu.slice(1)}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={() => loadMainMenu(true)}
+            className="rounded-xl bg-white px-4 py-2 text-sm font-semibold text-blue-600 transition hover:bg-blue-50"
+          >
+            Обновить меню
+          </button>
+          <button
+            onClick={() => signOut({ callbackUrl: '/' })}
+            className="rounded-xl border border-white/40 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20"
+          >
+            Выйти
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4 rounded-3xl bg-white p-6 shadow-lg">
+        <div className="flex items-center justify-between">
+          <h3 className="text-xl font-semibold text-primary">Диалог с ActQuest</h3>
+          {isLoading ? <span className="text-sm text-blue-500">Загрузка…</span> : null}
+        </div>
+        <div className="h-[420px] overflow-y-auto rounded-2xl bg-gray-50 p-4">
+          {history.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-sm text-gray-500">
+              Нажмите на кнопку, чтобы получить меню бота.
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {history.map((entry, index) => (
+                <ConversationEntry key={index} entry={entry} />
+              ))}
+            </div>
+          )}
+        </div>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3 md:flex-row">
+          <input
+            type="text"
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            placeholder="Введите команду или ответ..."
+            className="flex-1 rounded-2xl border border-gray-200 px-4 py-3 text-base shadow-sm focus:border-blue-400 focus:outline-none focus:ring"
+          />
+          <button
+            type="submit"
+            className="rounded-2xl bg-blue-600 px-6 py-3 text-base font-semibold text-white transition hover:bg-blue-700"
+          >
+            Отправить
+          </button>
+        </form>
+        {error ? <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-600">{error}</div> : null}
+      </div>
+    </div>
+  )
+
+  return (
+    <>
+      <Head>
+        <title>ActQuest — Личный кабинет</title>
+      </Head>
+      <div className="min-h-screen bg-[#F5F6F8] pb-16">
+        <header className="border-b border-gray-200 bg-white">
+          <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-5">
+            <Link href="/" className="text-2xl font-bold text-primary">
+              ActQuest
+            </Link>
+            <nav className="flex items-center gap-6 text-sm font-semibold text-gray-600">
+              <Link href="/" className="transition hover:text-primary">
+                Главная
+              </Link>
+              <a
+                href="https://t.me/ActQuest_dev_bot"
+                className="transition hover:text-primary"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Бот в Telegram
+              </a>
+            </nav>
+          </div>
+        </header>
+
+        <main className="px-4">
+          <div className="mx-auto mt-10 max-w-4xl text-center">
+            <h1 className="text-3xl font-bold text-primary md:text-4xl">
+              Управляйте квестами и командами в веб-интерфейсе ActQuest
+            </h1>
+            <p className="mt-4 text-lg text-gray-600">
+              Все функции Telegram-бота, но с большими экранами, быстрым доступом к действиям и удобной
+              навигацией.
+            </p>
+          </div>
+
+          {session ? renderDashboard() : renderLogin()}
+        </main>
+      </div>
+    </>
+  )
+}
+
+export default CabinetPage

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,39 +1,208 @@
 import Head from 'next/head'
-// import { TLoginButton, TLoginButtonSize } from 'react-telegram-auth'
+import Link from 'next/link'
+import { LOCATIONS } from '@server/serverConstants'
 
-export default function Home(props) {
+const features = [
+  {
+    title: 'Управление играми',
+    description:
+      'Создавайте квесты, редактируйте сценарии, запускайте и завершайте игры в несколько кликов.',
+  },
+  {
+    title: 'Командная работа',
+    description:
+      'Формируйте команды, приглашайте участников по ссылке и распределяйте роли прямо из веб-интерфейса.',
+  },
+  {
+    title: 'Гибкое администрирование',
+    description:
+      'Все инструменты Telegram-бота доступны в удобной панели: сообщения, подсказки, штрафы и статистика.',
+  },
+]
+
+const steps = [
+  {
+    title: 'Авторизуйтесь через Telegram',
+    description:
+      'Используйте официальный виджет Telegram, чтобы безопасно войти в систему и синхронизировать данные с ботом.',
+  },
+  {
+    title: 'Выберите регион',
+    description:
+      'ActQuest поддерживает несколько городов. Работайте с теми играми и командами, которые вам нужны.',
+  },
+  {
+    title: 'Работайте в личном кабинете',
+    description:
+      'Вы получаете все функции бота с преимуществами веб-интерфейса: быстрый поиск, история действий и большие экраны.',
+  },
+]
+
+const Home = () => {
+  const availableLocations = Object.entries(LOCATIONS).filter(([, value]) => !value.hidden)
+
   return (
     <>
       <Head>
-        <title>{`ActQuest`}</title>
+        <title>ActQuest — платформа для активных квестов</title>
       </Head>
-      <div>{'ActQuest'}</div>
-      {/* <TLoginButton
-        botName="ActQuest_dev_bot"
-        buttonSize={TLoginButtonSize.Large}
-        lang="ru"
-        usePic={false}
-        cornerRadius={20}
-        onAuthCallback={(user) => {
-          console.log('Hello, user!', user)
-        }}
-        requestAccess={'write'}
-        additionalClasses={'css-class-for-wrapper'}
-      />
-      <div>раврв</div> */}
-      {/* <Script
-        async
-        src="https://telegram.org/js/telegram-widget.js?22"
-        data-telegram-login="ActQuest_dev_bot"
-        data-size="large"
-        data-onauth="onTelegramAuth(user)"
-        data-request-access="write"
-      ></Script>
-      <Script type="text/javascript">
-        {`function onTelegramAuth(user) {
-    alert('Logged in as ' + user.first_name + ' ' + user.last_name + ' (' + user.id + (user.username ? ', @' + user.username : '') + ')');
-  }`}
-      </Script> */}
+      <div className="min-h-screen bg-[#F5F6F8] text-[#1C1D1F]">
+        <header className="border-b border-gray-200 bg-white">
+          <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-5">
+            <span className="text-2xl font-bold text-primary">ActQuest</span>
+            <nav className="flex items-center gap-6 text-sm font-semibold text-gray-600">
+              <Link href="/cabinet" className="transition hover:text-primary">
+                Личный кабинет
+              </Link>
+              <a
+                href="https://t.me/ActQuest_dev_bot"
+                className="transition hover:text-primary"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Бот в Telegram
+              </a>
+            </nav>
+          </div>
+        </header>
+
+        <main className="px-4">
+          <section className="mx-auto flex max-w-6xl flex-col gap-10 py-16 lg:flex-row lg:items-center">
+            <div className="lg:w-1/2">
+              <h1 className="text-4xl font-bold text-primary md:text-5xl">
+                Активные квесты в Telegram и на веб-платформе
+              </h1>
+              <p className="mt-6 text-lg text-gray-600">
+                ActQuest объединяет участников и организаторов квестов. Управляйте командами, играми и заданиями
+                через удобный веб-интерфейс, полностью синхронизированный с Telegram-ботом.
+              </p>
+              <div className="mt-8 flex flex-col gap-4 sm:flex-row">
+                <Link
+                  href="/cabinet"
+                  className="inline-flex items-center justify-center rounded-2xl bg-blue-600 px-6 py-3 text-base font-semibold text-white shadow-lg transition hover:bg-blue-700"
+                >
+                  Перейти в личный кабинет
+                </Link>
+                <a
+                  href="https://t.me/ActQuest_dev_bot"
+                  className="inline-flex items-center justify-center rounded-2xl border border-blue-200 bg-blue-50 px-6 py-3 text-base font-semibold text-blue-700 transition hover:bg-blue-100"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Открыть Telegram-бота
+                </a>
+              </div>
+            </div>
+            <div className="lg:w-1/2">
+              <div className="rounded-3xl bg-white p-8 shadow-xl">
+                <h2 className="text-xl font-semibold text-primary">Что вы получаете</h2>
+                <ul className="mt-6 space-y-5">
+                  {features.map((feature) => (
+                    <li key={feature.title} className="flex gap-4">
+                      <span className="mt-1 h-2 w-2 rounded-full bg-blue-500" aria-hidden="true" />
+                      <div>
+                        <h3 className="text-lg font-semibold text-primary">{feature.title}</h3>
+                        <p className="mt-1 text-sm text-gray-600">{feature.description}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          <section className="mx-auto max-w-6xl rounded-3xl bg-white p-8 shadow-lg">
+            <h2 className="text-2xl font-bold text-primary">Как начать работу</h2>
+            <div className="mt-8 grid gap-6 md:grid-cols-3">
+              {steps.map((step, index) => (
+                <div key={step.title} className="flex flex-col gap-3 rounded-2xl border border-gray-200 p-6">
+                  <span className="h-10 w-10 rounded-full bg-blue-600 text-center text-lg font-semibold leading-10 text-white">
+                    {index + 1}
+                  </span>
+                  <h3 className="text-lg font-semibold text-primary">{step.title}</h3>
+                  <p className="text-sm text-gray-600">{step.description}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="mx-auto mt-12 max-w-6xl">
+            <div className="rounded-3xl bg-gradient-to-r from-purple-600 to-blue-600 p-8 text-white shadow-xl">
+              <h2 className="text-2xl font-semibold">ActQuest развивается в разных городах</h2>
+              <p className="mt-3 text-sm text-blue-100">
+                Мы поддерживаем несколько площадок. Выбирайте нужный регион в личном кабинете — и получите доступ к
+                играм и командам вашего города.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-3">
+                {availableLocations.map(([key, value]) => (
+                  <span
+                    key={key}
+                    className="rounded-full bg-white/15 px-4 py-2 text-sm font-semibold text-white shadow-sm"
+                  >
+                    {value.townRu[0].toUpperCase() + value.townRu.slice(1)}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="mx-auto mt-16 max-w-6xl pb-20">
+            <div className="rounded-3xl bg-white p-8 shadow-lg">
+              <h2 className="text-2xl font-bold text-primary">Для кого ActQuest</h2>
+              <div className="mt-6 grid gap-6 md:grid-cols-3">
+                <div className="rounded-2xl border border-gray-200 p-6">
+                  <h3 className="text-lg font-semibold text-primary">Организаторы игр</h3>
+                  <p className="mt-2 text-sm text-gray-600">
+                    Настройка квестов, автоматизация выдачи заданий, контроль подсказок и штрафов.
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-gray-200 p-6">
+                  <h3 className="text-lg font-semibold text-primary">Капитаны команд</h3>
+                  <p className="mt-2 text-sm text-gray-600">
+                    Управление составом, приглашения для участников и мгновенное взаимодействие с организаторами.
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-gray-200 p-6">
+                  <h3 className="text-lg font-semibold text-primary">Игроки</h3>
+                  <p className="mt-2 text-sm text-gray-600">
+                    Быстрый доступ к заданиям, подсказкам и истории прохождения — на компьютере и в мобильном браузере.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-10 flex flex-col gap-4 rounded-2xl bg-blue-50 p-6 text-blue-800 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <h3 className="text-xl font-semibold">Готовы попробовать?</h3>
+                  <p className="mt-1 text-sm">
+                    Войдите в личный кабинет и управляйте играми, командами и участниками без ограничений.
+                  </p>
+                </div>
+                <Link
+                  href="/cabinet"
+                  className="inline-flex items-center justify-center rounded-2xl bg-blue-600 px-6 py-3 text-base font-semibold text-white shadow-lg transition hover:bg-blue-700"
+                >
+                  Перейти в личный кабинет
+                </Link>
+              </div>
+            </div>
+          </section>
+        </main>
+
+        <footer className="border-t border-gray-200 bg-white">
+          <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 text-sm text-gray-500 md:flex-row md:items-center md:justify-between">
+            <span>© {new Date().getFullYear()} ActQuest. Все права защищены.</span>
+            <div className="flex flex-wrap gap-4">
+              <a href="mailto:info@actquest.ru" className="hover:text-primary">
+                info@actquest.ru
+              </a>
+              <a href="https://t.me/ActQuest_dev_bot" className="hover:text-primary" target="_blank" rel="noreferrer">
+                Поддержка в Telegram
+              </a>
+            </div>
+          </div>
+        </footer>
+      </div>
     </>
   )
 }
+
+export default Home

--- a/schemas/usersSchema.js
+++ b/schemas/usersSchema.js
@@ -9,6 +9,23 @@ const usersSchema = {
     default: '',
     trim: true,
   },
+  username: {
+    type: String,
+    default: null,
+    trim: true,
+  },
+  photoUrl: {
+    type: String,
+    default: null,
+  },
+  languageCode: {
+    type: String,
+    default: null,
+  },
+  isPremium: {
+    type: Boolean,
+    default: false,
+  },
   gender: {
     type: String,
     default: null,

--- a/utils/telegram/getTelegramBotNameByLocation.js
+++ b/utils/telegram/getTelegramBotNameByLocation.js
@@ -1,0 +1,13 @@
+const botNames = {
+  dev: process.env.NEXT_PUBLIC_TELEGRAM_DEV_BOT_NAME || 'ActQuest_dev_bot',
+  krsk: process.env.NEXT_PUBLIC_TELEGRAM_KRSK_BOT_NAME,
+  nrsk: process.env.NEXT_PUBLIC_TELEGRAM_NRSK_BOT_NAME,
+  ekb: process.env.NEXT_PUBLIC_TELEGRAM_EKB_BOT_NAME,
+}
+
+const getTelegramBotNameByLocation = (location) => {
+  if (!location) return null
+  return botNames[location] || process.env.NEXT_PUBLIC_TELEGRAM_DEFAULT_BOT_NAME || null
+}
+
+export default getTelegramBotNameByLocation

--- a/utils/telegram/getTelegramTokenByLocation.js
+++ b/utils/telegram/getTelegramTokenByLocation.js
@@ -1,0 +1,13 @@
+const tokenByLocation = {
+  dev: process.env.TELEGRAM_DEV_TOKEN,
+  krsk: process.env.TELEGRAM_KRSK_TOKEN,
+  nrsk: process.env.TELEGRAM_NRSK_TOKEN,
+  ekb: process.env.TELEGRAM_EKB_TOKEN,
+}
+
+const getTelegramTokenByLocation = (location) => {
+  if (!location) return null
+  return tokenByLocation[location] || null
+}
+
+export default getTelegramTokenByLocation


### PR DESCRIPTION
## Summary
- redesign the public homepage with a new hero, feature highlights, and region information for ActQuest
- add a dedicated cabinet page that supports Telegram-based login, location selection, and an improved command interface
- implement Telegram login verification, extend NextAuth, expose a web command API, and enrich the user schema for the dashboard

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d81f4090f883299c33de0d2615cccf