### PR TITLE
Fix Telegram game buttons exceeding callback-data limit

### DIFF
--- a/telegram/func/commandShortcuts.js
+++ b/telegram/func/commandShortcuts.js
@@ -1,5 +1,6 @@
 const keyShortcuts = {
   gameId: 'g',
+  gameTeamId: 'gt',
   page: 'p',
   financeType: 'f',
   startYear: 'sy',
@@ -8,6 +9,8 @@ const keyShortcuts = {
   endMonth: 'em',
   startPickerYear: 'spy',
   endPickerYear: 'epy',
+  forceClue: 'fc',
+  failTask: 'ft',
 }
 
 const yearKeys = new Set([


### PR DESCRIPTION
## Summary
- shorten callback payload keys used in Telegram game buttons to keep inline callback data under the 64-byte Telegram limit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d962c029f083298945f65d045e4047