### PR TITLE
Fix persistence of force clue command state

### DIFF
--- a/telegram/func/executeCommand.js
+++ b/telegram/func/executeCommand.js
@@ -151,6 +151,12 @@ const executeCommand = async ({
     delete actualCommand.isVideo
     delete actualCommand.isDocument
 
+    ;['forceClue', 'confirmForceClue', 'failTask', 'confirmFailTask', 'finishBreak', 'confirmFinishBreak'].forEach(
+      (key) => {
+        if (key in actualCommand) delete actualCommand[key]
+      }
+    )
+
     return await db.model('LastCommands').findOneAndUpdate(
       {
         userTelegramId,


### PR DESCRIPTION
## Summary
- clear one-time captain action flags before storing the last command
- prevent subsequent text answers from being interpreted as another forced clue request

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac31f94908329a953064a7e0f4c2f