### PR TITLE
Clear clue penalties on restart and show task names in team addings

### DIFF
--- a/helpers/removeCluePenalties.js
+++ b/helpers/removeCluePenalties.js
@@ -1,0 +1,16 @@
+const isCluePenalty = ({ name, taskId, taskIndex }) => {
+  if (typeof name !== 'string') return false
+  const matchesClueName = name.startsWith('Досрочная подсказка')
+  if (!matchesClueName) return false
+
+  if (taskId) return true
+  return typeof taskIndex === 'number'
+}
+
+const removeCluePenalties = (timeAddings) => {
+  if (!Array.isArray(timeAddings)) return []
+
+  return timeAddings.filter((adding) => !isCluePenalty(adding))
+}
+
+export default removeCluePenalties

--- a/telegram/commands/gameTeamAddings.js
+++ b/telegram/commands/gameTeamAddings.js
@@ -20,15 +20,28 @@ const gameTeamAddings = async ({ telegramId, jsonCommand, location, db }) => {
   if (team.success === false) return team
 
   const page = jsonCommand?.page ?? 1
+  const tasksTitlesMap = new Map(
+    (game?.tasks ?? [])
+      .filter(({ _id }) => _id)
+      .map(({ _id, title }) => [String(_id), title])
+  )
+
+  const formatAddingName = ({ name, taskId }) => {
+    if (!taskId) return name
+    const taskTitle = tasksTitlesMap.get(String(taskId))
+    return taskTitle ? `${name} (${taskTitle})` : name
+  }
+
   const buttons = gameTeam?.timeAddings
     ? buttonListConstructor(
         gameTeam.timeAddings,
         page,
-        ({ id, name, time }, number) => {
+        (adding, number) => {
+          const { name, time } = adding
           return {
             text: `${number}. \u{1F5D1} ${
               time < 0 ? `\u{1F7E2}` : `\u{1F534}`
-            } ${name}`,
+            } ${formatAddingName(adding)}`,
             c: {
               c: `delGameTeamAdding${time < 0 ? 'Bonus' : 'Penalty'}`,
               gameTeamId: jsonCommand.gameTeamId,
@@ -44,10 +57,13 @@ const gameTeamAddings = async ({ telegramId, jsonCommand, location, db }) => {
       team?.name
     }"</b>\n\n<b>Текущие бонусы/штрафы:</b>${
       gameTeam?.timeAddings && gameTeam.timeAddings.length > 0
-        ? gameTeam.timeAddings.map(({ name, time }) => {
+        ? gameTeam.timeAddings.map((adding) => {
+            const { name, time } = adding
             return `\n${
               time < 0 ? `\u{1F7E2}` : `\u{1F534}`
-            } ${secondsToTimeStr(Math.abs(time), true)} - ${name}`
+            } ${secondsToTimeStr(Math.abs(time), true)} - ${formatAddingName(
+              adding
+            )}`
           })
         : ' отсутвуют'
     }`,

--- a/telegram/commands/gameTeamAdmin.js
+++ b/telegram/commands/gameTeamAdmin.js
@@ -53,6 +53,18 @@ const gameTeamAdmin = async ({ telegramId, jsonCommand, user, db }) => {
     url: `t.me/+${user.phone}`,
   }))
 
+  const tasksTitlesMap = new Map(
+    (game?.tasks ?? [])
+      .filter(({ _id }) => _id)
+      .map(({ _id, title }) => [String(_id), title])
+  )
+
+  const formatAddingName = ({ name, taskId }) => {
+    if (!taskId) return name
+    const taskTitle = tasksTitlesMap.get(String(taskId))
+    return taskTitle ? `${name} (${taskTitle})` : name
+  }
+
   return {
     message: `<b>Игра ${formatGameName(game)}\n\nКоманда "${
       team?.name
@@ -65,10 +77,13 @@ const gameTeamAdmin = async ({ telegramId, jsonCommand, user, db }) => {
       )
       .join('\n')}\n\n<b>Текущие бонусы/штрафы:</b>${
       gameTeam?.timeAddings && gameTeam.timeAddings.length > 0
-        ? gameTeam.timeAddings.map(({ name, time }) => {
+        ? gameTeam.timeAddings.map((adding) => {
+            const { name, time } = adding
             return `\n${
               time < 0 ? `\u{1F7E2}` : `\u{1F534}`
-            } ${secondsToTimeStr(Math.abs(time), true)} - ${name}`
+            } ${secondsToTimeStr(Math.abs(time), true)} - ${formatAddingName(
+              adding
+            )}`
           })
         : ' отсутвуют'
     }\n\n<b>Суммарно оплачено командой</b>: ${paymentsOfUsers.reduce(


### PR DESCRIPTION
## Summary
- remove stored early-clue penalties when teams restart, both during mass start and individual restarts
- add shared helper to filter clue penalties
- display task titles next to addings that reference a task in team admin and editing screens

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68dad133fe888329aaf44a86855033a1