### PR TITLE
Добавить загрузку данных кабинета из БД и расширить редактор игр

### DIFF
--- a/helpers/formatRelativeTimeFromNow.js
+++ b/helpers/formatRelativeTimeFromNow.js
@@ -1,0 +1,58 @@
+const UNITS = [
+  { unit: 'minute', ms: 60 * 1000, limit: 60 },
+  { unit: 'hour', ms: 60 * 60 * 1000, limit: 24 },
+  { unit: 'day', ms: 24 * 60 * 60 * 1000, limit: 7 },
+  { unit: 'week', ms: 7 * 24 * 60 * 60 * 1000, limit: 4 },
+  { unit: 'month', ms: 30 * 24 * 60 * 60 * 1000, limit: 12 },
+  { unit: 'year', ms: 365 * 24 * 60 * 60 * 1000, limit: Infinity },
+]
+
+const DEFAULT_LOCALE = 'ru'
+const DEFAULT_FALLBACK = '—'
+
+const formatRelativeTimeFromNow = (value, options = {}) => {
+  const { fallback = DEFAULT_FALLBACK, locale = DEFAULT_LOCALE } = options
+
+  if (!value) {
+    return fallback
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return fallback
+  }
+
+  const diffMs = date.getTime() - Date.now()
+  const absDiffMs = Math.abs(diffMs)
+
+  if (absDiffMs < 45 * 1000) {
+    return diffMs <= 0 ? 'только что' : 'через несколько секунд'
+  }
+
+  const hasRelativeTimeFormat =
+    typeof Intl !== 'undefined' && typeof Intl.RelativeTimeFormat === 'function'
+
+  if (!hasRelativeTimeFormat) {
+    try {
+      return date.toLocaleString(locale)
+    } catch (error) {
+      return date.toISOString()
+    }
+  }
+
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
+
+  for (const { unit, ms, limit } of UNITS) {
+    const diff = diffMs / ms
+
+    if (Math.abs(diff) < limit) {
+      return formatter.format(Math.round(diff), unit)
+    }
+  }
+
+  const yearsDiff = diffMs / UNITS[UNITS.length - 1].ms
+  return formatter.format(Math.round(yearsDiff), 'year')
+}
+
+export default formatRelativeTimeFromNow

--- a/helpers/getGameStatusLabel.js
+++ b/helpers/getGameStatusLabel.js
@@ -1,0 +1,18 @@
+const STATUS_LABELS = {
+  active: 'Активна',
+  started: 'Запущена',
+  finished: 'Завершена',
+  canceled: 'Отменена',
+}
+
+const getGameStatusLabel = (status) => {
+  if (!status) {
+    return 'Без статуса'
+  }
+
+  const normalized = typeof status === 'string' ? status.toLowerCase() : String(status)
+
+  return STATUS_LABELS[normalized] ?? 'Неизвестный статус'
+}
+
+export default getGameStatusLabel

--- a/helpers/normalizeGameForCabinet.js
+++ b/helpers/normalizeGameForCabinet.js
@@ -1,0 +1,154 @@
+const ensureString = (value, fallback = '') => {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  if (typeof value.toString === 'function') {
+    const result = value.toString()
+    return result === '[object Object]' ? fallback : result
+  }
+
+  return fallback
+}
+
+const ensureNumber = (value, fallback = 0) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+const ensureBoolean = (value, fallback = false) => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  if (value === 'true') return true
+  if (value === 'false') return false
+
+  return Boolean(value)
+}
+
+const ensureDateISOString = (value) => {
+  if (!value) {
+    return null
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toISOString()
+}
+
+const normalizePrices = (prices = []) => {
+  if (!Array.isArray(prices) || prices.length === 0) {
+    return []
+  }
+
+  return prices.map((price, index) => ({
+    id: ensureString(price?.id, `price-${index}`),
+    name: ensureString(price?.name, ''),
+    price: ensureNumber(price?.price, 0),
+  }))
+}
+
+const normalizeFinances = (finances = []) => {
+  if (!Array.isArray(finances) || finances.length === 0) {
+    return []
+  }
+
+  return finances.map((entry, index) => ({
+    id: ensureString(entry?.id, `finance-${index}`),
+    type: entry?.type === 'expense' ? 'expense' : 'income',
+    sum: ensureNumber(entry?.sum, 0),
+    date: ensureDateISOString(entry?.date),
+    description: ensureString(entry?.description, ''),
+  }))
+}
+
+const normalizeManyCodesPenalty = (value) => {
+  if (!Array.isArray(value) || value.length < 2) {
+    return [0, 0]
+  }
+
+  return [ensureNumber(value[0], 0), ensureNumber(value[1], 0)]
+}
+
+const computeTasksStats = (tasks = []) => {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return { total: 0, bonus: 0, canceled: 0 }
+  }
+
+  return tasks.reduce(
+    (acc, task) => {
+      if (task?.canceled) {
+        acc.canceled += 1
+        return acc
+      }
+
+      if (task?.isBonusTask) {
+        acc.bonus += 1
+      } else {
+        acc.total += 1
+      }
+
+      return acc
+    },
+    { total: 0, bonus: 0, canceled: 0 }
+  )
+}
+
+const normalizeGameForCabinet = (game) => {
+  if (!game) {
+    return null
+  }
+
+  const id = ensureString(game._id ?? game.id)
+  const tasksStats = computeTasksStats(game.tasks)
+
+  return {
+    id,
+    name: ensureString(game.name, ''),
+    status: ensureString(game.status, 'active'),
+    dateStart: ensureDateISOString(game.dateStart),
+    dateStartFact: ensureDateISOString(game.dateStartFact),
+    dateEndFact: ensureDateISOString(game.dateEndFact),
+    type: game?.type === 'photo' ? 'photo' : 'classic',
+    description: ensureString(game.description, ''),
+    image: ensureString(game.image, ''),
+    startingPlace: ensureString(game.startingPlace, ''),
+    finishingPlace: ensureString(game.finishingPlace, ''),
+    taskDuration: ensureNumber(game.taskDuration, 3600),
+    cluesDuration: ensureNumber(game.cluesDuration, 1200),
+    clueEarlyAccessMode: game?.clueEarlyAccessMode === 'penalty' ? 'penalty' : 'time',
+    clueEarlyPenalty: ensureNumber(game.clueEarlyPenalty, 0),
+    allowCaptainForceClue: ensureBoolean(game.allowCaptainForceClue, true),
+    allowCaptainFailTask: ensureBoolean(game.allowCaptainFailTask, true),
+    allowCaptainFinishBreak: ensureBoolean(game.allowCaptainFinishBreak, true),
+    breakDuration: ensureNumber(game.breakDuration, 0),
+    taskFailurePenalty: ensureNumber(game.taskFailurePenalty, 0),
+    manyCodesPenalty: normalizeManyCodesPenalty(game.manyCodesPenalty),
+    individualStart: ensureBoolean(game.individualStart, false),
+    hidden: ensureBoolean(game.hidden, true),
+    showCreator: ensureBoolean(game.showCreator, true),
+    showTasks: ensureBoolean(game.showTasks, false),
+    hideResult: ensureBoolean(game.hideResult, false),
+    prices: normalizePrices(game.prices),
+    finances: normalizeFinances(game.finances),
+    teamsCount: ensureNumber(game.teamsCount, 0),
+    tasksStats,
+    updatedAt: ensureDateISOString(game.updatedAt),
+    createdAt: ensureDateISOString(game.createdAt),
+    creatorTelegramId: ensureString(game.creatorTelegramId, ''),
+  }
+}
+
+export default normalizeGameForCabinet

--- a/pages/cabinet/games.js
+++ b/pages/cabinet/games.js
@@ -1,80 +1,385 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
 import Head from 'next/head'
+import { useSession } from 'next-auth/react'
+
 import CabinetLayout from '@components/cabinet/CabinetLayout'
 import getSessionSafe from '@helpers/getSessionSafe'
+import formatDate from '@helpers/formatDate'
+import formatDateTime from '@helpers/formatDateTime'
+import formatRelativeTimeFromNow from '@helpers/formatRelativeTimeFromNow'
+import getGameStatusLabel from '@helpers/getGameStatusLabel'
+import normalizeGameForCabinet from '@helpers/normalizeGameForCabinet'
+import { getNounBonusTasks, getNounTasks, getNounTeams } from '@helpers/getNoun'
+import dbConnect from '@utils/dbConnect'
 
-const initialGames = [
-  {
-    id: 'game-1',
-    title: 'Весенний забег',
-    status: 'Черновик',
-    startDate: '2024-04-18',
-    teamsLimit: 12,
-    isPublished: false,
-    description:
-      'Городская игра с заданиями в историческом центре. Включает 5 этапов и финальный пазл.',
-  },
-  {
-    id: 'game-2',
-    title: 'Ночная прогулка',
-    status: 'Опубликована',
-    startDate: '2024-05-04',
-    teamsLimit: 8,
-    isPublished: true,
-    description:
-      'Маршрут по неоновой части города. Задания построены на взаимодействии с подсветкой и витринами.',
-  },
-  {
-    id: 'game-3',
-    title: 'Квест для новичков',
-    status: 'В подготовке',
-    startDate: '2024-05-20',
-    teamsLimit: 16,
-    isPublished: false,
-    description:
-      'Серия из трёх ознакомительных сценариев. Отлично подходит для корпоративных команд.',
-  },
+const GAME_STATUS_OPTIONS = ['active', 'started', 'finished', 'canceled'].map((value) => ({
+  value,
+  label: getGameStatusLabel(value),
+}))
+
+const GAME_TYPE_OPTIONS = [
+  { value: 'classic', label: 'Классика' },
+  { value: 'photo', label: 'Фотоквест' },
 ]
 
-const statusOptions = ['Черновик', 'В подготовке', 'Опубликована', 'Завершена']
+const CLUE_EARLY_MODE_OPTIONS = [
+  { value: 'time', label: 'Добавить время до следующей подсказки' },
+  { value: 'penalty', label: 'Штраф организатора за подсказку' },
+]
 
-const GamesPage = () => {
+const toMinutes = (seconds) => {
+  const numeric = Number(seconds)
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 0
+  }
+  return Math.round(numeric / 60)
+}
+
+const toSeconds = (minutes) => {
+  const numeric = Number(minutes)
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 0
+  }
+  return Math.round(numeric * 60)
+}
+
+const createPrice = () => ({
+  id: `price-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+  name: '',
+  price: 0,
+})
+
+const createFinanceEntry = () => {
+  const now = new Date()
+  return {
+    id: `finance-${now.getTime()}-${Math.random().toString(36).slice(2, 6)}`,
+    type: 'income',
+    sum: 0,
+    date: now.toISOString(),
+    description: '',
+  }
+}
+
+const serializeGameForComparison = (game) => {
+  if (!game) {
+    return null
+  }
+
+  const {
+    id,
+    teamsCount,
+    tasksStats,
+    updatedAt,
+    createdAt,
+    dateStartFact,
+    dateEndFact,
+    ...rest
+  } = game
+
+  const normalizeArray = (array) =>
+    (Array.isArray(array) ? array : [])
+      .map((item) => ({ ...item }))
+      .sort((a, b) => (a.id || '').localeCompare(b.id || ''))
+
+  return JSON.stringify({
+    ...rest,
+    prices: normalizeArray(rest.prices),
+    finances: normalizeArray(rest.finances),
+  })
+}
+
+const buildUpdatePayload = (game) => {
+  const prices = (game.prices ?? []).map((price) => ({
+    id: price.id,
+    name: price.name,
+    price: Number(price.price) || 0,
+  }))
+
+  const finances = (game.finances ?? []).map((entry) => ({
+    id: entry.id,
+    type: entry.type === 'expense' ? 'expense' : 'income',
+    sum: Number(entry.sum) || 0,
+    date: entry.date ? new Date(entry.date).toISOString() : null,
+    description: entry.description,
+  }))
+
+  const manyCodesPenalty = Array.isArray(game.manyCodesPenalty)
+    ? [Number(game.manyCodesPenalty[0]) || 0, Number(game.manyCodesPenalty[1]) || 0]
+    : [0, 0]
+
+  return {
+    name: game.name,
+    status: game.status,
+    dateStart: game.dateStart ? new Date(game.dateStart).toISOString() : null,
+    type: game.type,
+    description: game.description,
+    image: game.image ? game.image : null,
+    startingPlace: game.startingPlace ?? '',
+    finishingPlace: game.finishingPlace ?? '',
+    taskDuration: Number(game.taskDuration) || 0,
+    cluesDuration: Number(game.cluesDuration) || 0,
+    clueEarlyAccessMode: game.clueEarlyAccessMode,
+    clueEarlyPenalty: Number(game.clueEarlyPenalty) || 0,
+    allowCaptainForceClue: Boolean(game.allowCaptainForceClue),
+    allowCaptainFailTask: Boolean(game.allowCaptainFailTask),
+    allowCaptainFinishBreak: Boolean(game.allowCaptainFinishBreak),
+    breakDuration: Number(game.breakDuration) || 0,
+    taskFailurePenalty: Number(game.taskFailurePenalty) || 0,
+    manyCodesPenalty,
+    individualStart: Boolean(game.individualStart),
+    hidden: Boolean(game.hidden),
+    showCreator: Boolean(game.showCreator),
+    showTasks: Boolean(game.showTasks),
+    hideResult: Boolean(game.hideResult),
+    prices,
+    finances,
+  }
+}
+
+const GamesPage = ({ initialGames, initialLocation }) => {
+  const { data: session } = useSession()
+  const location = session?.user?.location ?? initialLocation ?? null
+
   const [games, setGames] = useState(initialGames)
-  const [selectedGameId, setSelectedGameId] = useState(initialGames[0].id)
+  const [persistedGames, setPersistedGames] = useState(initialGames)
+  const [selectedGameId, setSelectedGameId] = useState(initialGames[0]?.id ?? null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [feedback, setFeedback] = useState(null)
+
+  useEffect(() => {
+    setGames(initialGames)
+    setPersistedGames(initialGames)
+    setSelectedGameId((prev) => {
+      if (prev && initialGames.some((game) => game.id === prev)) {
+        return prev
+      }
+      return initialGames[0]?.id ?? null
+    })
+  }, [initialGames])
+
+  useEffect(() => {
+    setFeedback(null)
+  }, [selectedGameId])
+
+  const numberFormatter = useMemo(() => new Intl.NumberFormat('ru-RU'), [])
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat('ru-RU', {
+        style: 'currency',
+        currency: 'RUB',
+        maximumFractionDigits: 0,
+      }),
+    []
+  )
 
   const selectedGame = useMemo(
-    () => games.find((game) => game.id === selectedGameId),
+    () => games.find((game) => game.id === selectedGameId) ?? null,
     [games, selectedGameId]
   )
 
-  const updateSelectedGame = (field, value) => {
-    setGames((prevGames) =>
-      prevGames.map((game) =>
-        game.id === selectedGameId
-          ? {
-              ...game,
-              [field]: value,
-            }
-          : game
-      )
-    )
-  }
+  const persistedSelectedGame = useMemo(
+    () => persistedGames.find((game) => game.id === selectedGameId) ?? null,
+    [persistedGames, selectedGameId]
+  )
 
-  const addNewGame = () => {
-    const newGame = {
-      id: `game-${Date.now()}`,
-      title: 'Новая игра',
-      status: 'Черновик',
-      startDate: new Date().toISOString().slice(0, 10),
-      teamsLimit: 10,
-      isPublished: false,
-      description: 'Опишите детали сценария и этапы прохождения.',
+  const isDirty = useMemo(() => {
+    if (!selectedGame || !persistedSelectedGame) {
+      return false
     }
 
-    setGames((prevGames) => [newGame, ...prevGames])
-    setSelectedGameId(newGame.id)
-  }
+    return (
+      serializeGameForComparison(selectedGame) !==
+      serializeGameForComparison(persistedSelectedGame)
+    )
+  }, [persistedSelectedGame, selectedGame])
 
+  const updateSelectedGame = useCallback(
+    (updater) => {
+      if (!selectedGameId) return
+
+      setGames((prevGames) =>
+        prevGames.map((game) => {
+          if (game.id !== selectedGameId) {
+            return game
+          }
+
+          const patch = typeof updater === 'function' ? updater(game) : updater
+          return { ...game, ...patch }
+        })
+      )
+    },
+    [selectedGameId]
+  )
+
+  const handleResetChanges = useCallback(() => {
+    if (!selectedGameId) return
+
+    setGames((prevGames) =>
+      prevGames.map((game) => {
+        if (game.id !== selectedGameId) {
+          return game
+        }
+
+        const original = persistedGames.find((item) => item.id === selectedGameId)
+        return original ? { ...original } : game
+      })
+    )
+    setFeedback(null)
+  }, [persistedGames, selectedGameId])
+
+  const handleSaveChanges = useCallback(async () => {
+    if (!selectedGame || !location) return
+
+    setIsSaving(true)
+    setFeedback(null)
+
+    try {
+      const response = await fetch(`/api/${location}/games/${selectedGame.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: buildUpdatePayload(selectedGame) }),
+      })
+
+      const json = await response.json()
+
+      if (!response.ok || json?.success === false) {
+        throw new Error(json?.error || 'Не удалось сохранить игру')
+      }
+
+      const normalizedGame = normalizeGameForCabinet({
+        ...json.data,
+        teamsCount: selectedGame.teamsCount,
+      })
+
+      setGames((prevGames) =>
+        prevGames.map((game) => (game.id === normalizedGame.id ? normalizedGame : game))
+      )
+      setPersistedGames((prevGames) =>
+        prevGames.map((game) => (game.id === normalizedGame.id ? normalizedGame : game))
+      )
+      setFeedback({ type: 'success', message: 'Изменения сохранены' })
+    } catch (error) {
+      console.error('Failed to update game', error)
+      setFeedback({
+        type: 'error',
+        message: error?.message || 'Не удалось сохранить игру',
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }, [location, selectedGame])
+
+  const handleAddPrice = useCallback(() => {
+    updateSelectedGame((game) => ({
+      prices: [...(game.prices ?? []), createPrice()],
+    }))
+  }, [updateSelectedGame])
+
+  const handlePriceChange = useCallback(
+    (priceId, field, value) => {
+      updateSelectedGame((game) => ({
+        prices: (game.prices ?? []).map((price) =>
+          price.id === priceId
+            ? {
+                ...price,
+                [field]: field === 'price' ? Math.max(0, Number(value) || 0) : value,
+              }
+            : price
+        ),
+      }))
+    },
+    [updateSelectedGame]
+  )
+
+  const handleRemovePrice = useCallback(
+    (priceId) => {
+      updateSelectedGame((game) => ({
+        prices: (game.prices ?? []).filter((price) => price.id !== priceId),
+      }))
+    },
+    [updateSelectedGame]
+  )
+
+  const handleAddFinance = useCallback(() => {
+    updateSelectedGame((game) => ({
+      finances: [...(game.finances ?? []), createFinanceEntry()],
+    }))
+  }, [updateSelectedGame])
+
+  const handleFinanceChange = useCallback(
+    (financeId, field, value) => {
+      updateSelectedGame((game) => ({
+        finances: (game.finances ?? []).map((entry) => {
+          if (entry.id !== financeId) {
+            return entry
+          }
+
+          if (field === 'sum') {
+            return { ...entry, sum: Math.max(0, Number(value) || 0) }
+          }
+
+          if (field === 'date') {
+            return { ...entry, date: value ? new Date(value).toISOString() : null }
+          }
+
+          if (field === 'type') {
+            return { ...entry, type: value === 'expense' ? 'expense' : 'income' }
+          }
+
+          return { ...entry, [field]: value }
+        }),
+      }))
+    },
+    [updateSelectedGame]
+  )
+
+  const handleRemoveFinance = useCallback(
+    (financeId) => {
+      updateSelectedGame((game) => ({
+        finances: (game.finances ?? []).filter((entry) => entry.id !== financeId),
+      }))
+    },
+    [updateSelectedGame]
+  )
+
+  const tasksSummary = useMemo(() => {
+    if (!selectedGame?.tasksStats) {
+      return null
+    }
+
+    const { total, bonus, canceled } = selectedGame.tasksStats
+    return {
+      total,
+      bonus,
+      canceled,
+      totalLabel: getNounTasks(total),
+      bonusLabel: bonus > 0 ? getNounBonusTasks(bonus) : null,
+      canceledLabel: canceled > 0 ? `${canceled} отменено` : null,
+    }
+  }, [selectedGame])
+
+  const financesSummary = useMemo(() => {
+    if (!selectedGame?.finances) {
+      return { income: 0, expense: 0, balance: 0 }
+    }
+
+    const { income, expense } = selectedGame.finances.reduce(
+      (acc, entry) => {
+        if (entry.type === 'expense') {
+          acc.expense += Number(entry.sum) || 0
+        } else {
+          acc.income += Number(entry.sum) || 0
+        }
+        return acc
+      },
+      { income: 0, expense: 0 }
+    )
+
+    return { income, expense, balance: income - expense }
+  }, [selectedGame])
+
+  const balanceClass = financesSummary.balance >= 0 ? 'text-emerald-600' : 'text-rose-600'
   return (
     <>
       <Head>
@@ -87,140 +392,703 @@ const GamesPage = () => {
       >
         <section className="grid gap-6 md:grid-cols-5">
           <div className="md:col-span-2 space-y-4">
-            <button
-              type="button"
-              onClick={addNewGame}
-              className="flex items-center justify-center w-full px-4 py-3 text-sm font-semibold text-white transition bg-primary rounded-2xl hover:bg-blue-700"
-            >
-              Добавить игру
-            </button>
+            <div className="p-4 bg-white border border-slate-200 rounded-2xl shadow-sm">
+              <p className="text-sm font-semibold text-primary">Ваши игры</p>
+              <p className="mt-1 text-xs text-slate-500">
+                Выберите игру для редактирования основных настроек и финансовой информации.
+              </p>
+            </div>
 
-            <ul className="space-y-3">
-              {games.map((game) => (
-                <li key={game.id}>
-                  <button
-                    type="button"
-                    onClick={() => setSelectedGameId(game.id)}
-                    className={`w-full text-left p-4 border rounded-2xl transition hover:border-primary hover:bg-blue-50 ${
-                      selectedGameId === game.id
-                        ? 'border-primary bg-blue-50 shadow-sm'
-                        : 'border-slate-200 bg-white'
-                    }`}
-                  >
-                    <p className="text-sm font-semibold text-primary">{game.title}</p>
-                    <p className="mt-1 text-xs text-slate-500">{game.status}</p>
-                    <p className="mt-1 text-xs text-slate-400">
-                      Старт: {new Date(game.startDate).toLocaleDateString('ru-RU')}
-                    </p>
-                  </button>
-                </li>
-              ))}
-            </ul>
+            {games.length > 0 ? (
+              <ul className="space-y-3">
+                {games.map((game) => {
+                  const startDateLabel = game.dateStart
+                    ? new Date(game.dateStart).toLocaleString('ru-RU', {
+                        dateStyle: 'short',
+                        timeStyle: 'short',
+                      })
+                    : 'Дата не задана'
+
+                  const relativeUpdatedAt = game.updatedAt
+                    ? formatRelativeTimeFromNow(game.updatedAt)
+                    : '—'
+
+                  return (
+                    <li key={game.id}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedGameId(game.id)}
+                        className={`w-full text-left p-4 border rounded-2xl transition hover:border-primary hover:bg-blue-50 ${
+                          selectedGameId === game.id
+                            ? 'border-primary bg-blue-50 shadow-sm'
+                            : 'border-slate-200 bg-white'
+                        }`}
+                      >
+                        <p className="text-sm font-semibold text-primary">
+                          {game.name || 'Без названия'}
+                        </p>
+                        <p className="mt-1 text-xs text-slate-500">
+                          {getGameStatusLabel(game.status)} · {startDateLabel}
+                        </p>
+                        <p className="mt-1 text-xs text-slate-400">
+                          {getNounTeams(game.teamsCount)} · Обновлено {relativeUpdatedAt}
+                        </p>
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            ) : (
+              <div className="p-6 text-sm text-center text-slate-500 bg-white border border-slate-200 rounded-2xl shadow-sm">
+                Для выбранного города пока нет игр. Создайте сценарий в телеграм-боте, чтобы он появился здесь.
+              </div>
+            )}
           </div>
 
           <div className="md:col-span-3">
             {selectedGame ? (
-              <div className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
-                <div>
-                  <label htmlFor="game-title" className="text-sm font-semibold text-primary">
-                    Название игры
-                  </label>
-                  <input
-                    id="game-title"
-                    type="text"
-                    value={selectedGame.title}
-                    onChange={(event) => updateSelectedGame('title', event.target.value)}
-                    className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                  />
+              <div className="space-y-6">
+                <div className="p-5 bg-white border border-slate-200 rounded-2xl shadow-sm">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span className="px-2.5 py-1 text-xs font-semibold text-primary bg-blue-50 rounded-full">
+                      {getGameStatusLabel(selectedGame.status)}
+                    </span>
+                    <span className="text-xs text-slate-500">
+                      Команд: {numberFormatter.format(selectedGame.teamsCount ?? 0)}
+                    </span>
+                    {selectedGame.updatedAt && (
+                      <span className="text-xs text-slate-500">
+                        Обновлено {formatRelativeTimeFromNow(selectedGame.updatedAt)}
+                      </span>
+                    )}
+                  </div>
+                  {tasksSummary && (
+                    <p className="mt-3 text-sm text-slate-600">
+                      {tasksSummary.totalLabel}
+                      {tasksSummary.bonusLabel ? ` · ${tasksSummary.bonusLabel}` : ''}
+                      {tasksSummary.canceledLabel ? ` · ${tasksSummary.canceledLabel}` : ''}
+                    </p>
+                  )}
                 </div>
 
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div>
-                    <label htmlFor="game-status" className="text-sm font-semibold text-primary">
-                      Статус
-                    </label>
-                    <select
-                      id="game-status"
-                      value={selectedGame.status}
-                      onChange={(event) => updateSelectedGame('status', event.target.value)}
-                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                    >
-                      {statusOptions.map((option) => (
-                        <option key={option} value={option}>
-                          {option}
-                        </option>
-                      ))}
-                    </select>
+                {!location && (
+                  <div className="p-4 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-2xl">
+                    Не удалось определить площадку пользователя. Сохранение изменений недоступно.
+                  </div>
+                )}
+
+                {feedback && (
+                  <div
+                    className={`p-4 text-sm border rounded-2xl ${
+                      feedback.type === 'success'
+                        ? 'bg-emerald-50 border-emerald-200 text-emerald-700'
+                        : 'bg-rose-50 border-rose-200 text-rose-700'
+                    }`}
+                  >
+                    {feedback.message}
+                  </div>
+                )}
+
+                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-title" className="text-sm font-semibold text-primary">
+                        Название игры
+                      </label>
+                      <input
+                        id="game-title"
+                        type="text"
+                        value={selectedGame.name}
+                        onChange={(event) =>
+                          updateSelectedGame({ name: event.target.value })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="game-status" className="text-sm font-semibold text-primary">
+                        Статус
+                      </label>
+                      <select
+                        id="game-status"
+                        value={selectedGame.status}
+                        onChange={(event) =>
+                          updateSelectedGame({ status: event.target.value })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      >
+                        {GAME_STATUS_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
                   </div>
 
-                  <div>
-                    <label htmlFor="game-date" className="text-sm font-semibold text-primary">
-                      Дата старта
-                    </label>
-                    <input
-                      id="game-date"
-                      type="date"
-                      value={selectedGame.startDate}
-                      onChange={(event) => updateSelectedGame('startDate', event.target.value)}
-                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                    />
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-type" className="text-sm font-semibold text-primary">
+                        Тип игры
+                      </label>
+                      <select
+                        id="game-type"
+                        value={selectedGame.type}
+                        onChange={(event) =>
+                          updateSelectedGame({ type: event.target.value })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      >
+                        {GAME_TYPE_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label htmlFor="game-date" className="text-sm font-semibold text-primary">
+                        Плановое начало
+                      </label>
+                      <input
+                        id="game-date"
+                        type="datetime-local"
+                        value={
+                          selectedGame.dateStart
+                            ? formatDateTime(selectedGame.dateStart, true, true)
+                            : ''
+                        }
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            dateStart: event.target.value
+                              ? new Date(event.target.value).toISOString()
+                              : null,
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
                   </div>
-                </div>
 
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div>
-                    <label htmlFor="game-limit" className="text-sm font-semibold text-primary">
-                      Лимит команд
-                    </label>
+                  <div className="flex items-center gap-3">
                     <input
-                      id="game-limit"
-                      type="number"
-                      min="1"
-                      value={selectedGame.teamsLimit}
-                      onChange={(event) => updateSelectedGame('teamsLimit', Number(event.target.value))}
-                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                    />
-                  </div>
-
-                  <div className="flex items-center gap-3 mt-6 md:mt-[34px]">
-                    <input
-                      id="game-published"
+                      id="game-individual-start"
                       type="checkbox"
-                      checked={selectedGame.isPublished}
-                      onChange={(event) => updateSelectedGame('isPublished', event.target.checked)}
-                      className="w-4 h-4 text-primary border-slate-300 rounded focus:ring-primary"
+                      checked={Boolean(selectedGame.individualStart)}
+                      onChange={(event) =>
+                        updateSelectedGame({ individualStart: event.target.checked })
+                      }
+                      className="w-4 h-4 text-primary border-slate-300 rounded"
                     />
-                    <label htmlFor="game-published" className="text-sm text-slate-600">
-                      Игра опубликована
+                    <label htmlFor="game-individual-start" className="text-sm text-slate-600">
+                      Индивидуальный старт для команд
                     </label>
                   </div>
-                </div>
 
-                <div>
-                  <label htmlFor="game-description" className="text-sm font-semibold text-primary">
-                    Описание сценария
-                  </label>
-                  <textarea
-                    id="game-description"
-                    value={selectedGame.description}
-                    onChange={(event) => updateSelectedGame('description', event.target.value)}
-                    rows={6}
-                    className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                  />
-                </div>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-starting-place" className="text-sm font-semibold text-primary">
+                        Место сбора
+                      </label>
+                      <input
+                        id="game-starting-place"
+                        type="text"
+                        value={selectedGame.startingPlace}
+                        onChange={(event) =>
+                          updateSelectedGame({ startingPlace: event.target.value })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="game-finishing-place" className="text-sm font-semibold text-primary">
+                        Место окончания
+                      </label>
+                      <input
+                        id="game-finishing-place"
+                        type="text"
+                        value={selectedGame.finishingPlace}
+                        onChange={(event) =>
+                          updateSelectedGame({ finishingPlace: event.target.value })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                  </div>
 
-                <div className="flex flex-col gap-3 md:flex-row">
+                  <div>
+                    <label htmlFor="game-description" className="text-sm font-semibold text-primary">
+                      Описание
+                    </label>
+                    <textarea
+                      id="game-description"
+                      value={selectedGame.description}
+                      onChange={(event) =>
+                        updateSelectedGame({ description: event.target.value })
+                      }
+                      rows={5}
+                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                    />
+                  </div>
+
+                  <div>
+                    <label htmlFor="game-image" className="text-sm font-semibold text-primary">
+                      Ссылка на обложку
+                    </label>
+                    <input
+                      id="game-image"
+                      type="text"
+                      value={selectedGame.image}
+                      onChange={(event) =>
+                        updateSelectedGame({ image: event.target.value })
+                      }
+                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                    />
+                    {selectedGame.image && (
+                      <img
+                        src={selectedGame.image}
+                        alt={selectedGame.name || 'Обложка игры'}
+                        className="object-cover w-full h-40 mt-3 rounded-xl border border-slate-200"
+                      />
+                    )}
+                  </div>
+                </section>
+
+                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <h2 className="text-lg font-semibold text-primary">Настройки заданий и подсказок</h2>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-task-duration" className="text-sm font-semibold text-primary">
+                        Продолжительность задания (мин)
+                      </label>
+                      <input
+                        id="game-task-duration"
+                        type="number"
+                        min="0"
+                        value={toMinutes(selectedGame.taskDuration)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            taskDuration: toSeconds(event.target.value),
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="game-clues-duration" className="text-sm font-semibold text-primary">
+                        Время до подсказки (мин)
+                      </label>
+                      <input
+                        id="game-clues-duration"
+                        type="number"
+                        min="0"
+                        value={toMinutes(selectedGame.cluesDuration)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            cluesDuration: toSeconds(event.target.value),
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                      <p className="mt-1 text-xs text-slate-500">
+                        Укажите 0, чтобы отключить автоматическую выдачу подсказок.
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-clue-mode" className="text-sm font-semibold text-primary">
+                        Режим досрочной подсказки
+                      </label>
+                      <select
+                        id="game-clue-mode"
+                        value={selectedGame.clueEarlyAccessMode}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            clueEarlyAccessMode: event.target.value,
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      >
+                        {CLUE_EARLY_MODE_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label htmlFor="game-clue-penalty" className="text-sm font-semibold text-primary">
+                        {selectedGame.clueEarlyAccessMode === 'penalty'
+                          ? 'Штраф за досрочную подсказку (мин)'
+                          : 'Дополнительное время после подсказки (мин)'}
+                      </label>
+                      <input
+                        id="game-clue-penalty"
+                        type="number"
+                        min="0"
+                        value={toMinutes(selectedGame.clueEarlyPenalty)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            clueEarlyPenalty: toSeconds(event.target.value),
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-break-duration" className="text-sm font-semibold text-primary">
+                        Перерыв между заданиями (мин)
+                      </label>
+                      <input
+                        id="game-break-duration"
+                        type="number"
+                        min="0"
+                        value={toMinutes(selectedGame.breakDuration)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            breakDuration: toSeconds(event.target.value),
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="game-task-penalty" className="text-sm font-semibold text-primary">
+                        {selectedGame.type === 'photo'
+                          ? 'Штраф за невыполненное задание (баллы)'
+                          : 'Штраф за невыполненное задание (мин)'}
+                      </label>
+                      <input
+                        id="game-task-penalty"
+                        type="number"
+                        min="0"
+                        value={
+                          selectedGame.type === 'photo'
+                            ? Number(selectedGame.taskFailurePenalty) || 0
+                            : toMinutes(selectedGame.taskFailurePenalty)
+                        }
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            taskFailurePenalty:
+                              selectedGame.type === 'photo'
+                                ? Math.max(0, Number(event.target.value) || 0)
+                                : toSeconds(event.target.value),
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                  </div>
+
+                  {selectedGame.type !== 'photo' && (
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <div>
+                        <label htmlFor="game-many-codes-limit" className="text-sm font-semibold text-primary">
+                          Лимит неверных кодов для штрафа
+                        </label>
+                        <input
+                          id="game-many-codes-limit"
+                          type="number"
+                          min="0"
+                          value={selectedGame.manyCodesPenalty?.[0] ?? 0}
+                          onChange={(event) =>
+                            updateSelectedGame({
+                              manyCodesPenalty: [
+                                Math.max(0, Number(event.target.value) || 0),
+                                selectedGame.manyCodesPenalty?.[1] ?? 0,
+                              ],
+                            })
+                          }
+                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="game-many-codes-penalty" className="text-sm font-semibold text-primary">
+                          Штраф за превышение лимита (мин)
+                        </label>
+                        <input
+                          id="game-many-codes-penalty"
+                          type="number"
+                          min="0"
+                          value={toMinutes(selectedGame.manyCodesPenalty?.[1] ?? 0)}
+                          onChange={(event) =>
+                            updateSelectedGame({
+                              manyCodesPenalty: [
+                                selectedGame.manyCodesPenalty?.[0] ?? 0,
+                                toSeconds(event.target.value),
+                              ],
+                            })
+                          }
+                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="grid gap-3 md:grid-cols-3">
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.allowCaptainForceClue)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            allowCaptainForceClue: event.target.checked,
+                          })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Досрочные подсказки капитанам
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.allowCaptainFailTask)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            allowCaptainFailTask: event.target.checked,
+                          })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Слив задания капитаном
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.allowCaptainFinishBreak)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            allowCaptainFinishBreak: event.target.checked,
+                          })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Досрочное завершение перерыва
+                    </label>
+                  </div>
+                </section>
+
+                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <h2 className="text-lg font-semibold text-primary">Публикация и результаты</h2>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.hidden)}
+                        onChange={(event) =>
+                          updateSelectedGame({ hidden: event.target.checked })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Игра скрыта из общего списка
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.showCreator)}
+                        onChange={(event) =>
+                          updateSelectedGame({ showCreator: event.target.checked })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Показывать организатора игрокам
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.showTasks)}
+                        onChange={(event) =>
+                          updateSelectedGame({ showTasks: event.target.checked })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Открыть задания после завершения
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.hideResult)}
+                        onChange={(event) =>
+                          updateSelectedGame({ hideResult: event.target.checked })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Скрыть результаты для участников
+                    </label>
+                  </div>
+                </section>
+
+                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-lg font-semibold text-primary">Стоимость участия</h2>
+                    <button
+                      type="button"
+                      onClick={handleAddPrice}
+                      className="px-3 py-2 text-xs font-semibold text-white bg-primary rounded-xl hover:bg-blue-700"
+                    >
+                      Добавить тариф
+                    </button>
+                  </div>
+
+                  {(selectedGame.prices ?? []).length > 0 ? (
+                    <div className="space-y-3">
+                      {selectedGame.prices.map((price) => (
+                        <div
+                          key={price.id}
+                          className="grid gap-3 md:grid-cols-[2fr_1fr_auto] items-center p-4 border border-slate-200 rounded-2xl"
+                        >
+                          <input
+                            type="text"
+                            value={price.name}
+                            onChange={(event) =>
+                              handlePriceChange(price.id, 'name', event.target.value)
+                            }
+                            placeholder="Название тарифа"
+                            className="w-full px-4 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          />
+                          <input
+                            type="number"
+                            min="0"
+                            value={price.price}
+                            onChange={(event) =>
+                              handlePriceChange(price.id, 'price', event.target.value)
+                            }
+                            placeholder="Стоимость"
+                            className="w-full px-4 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => handleRemovePrice(price.id)}
+                            className="px-3 py-2 text-xs font-semibold text-rose-600 border border-rose-200 rounded-xl hover:bg-rose-50"
+                          >
+                            Удалить
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-500">
+                      Добавьте тариф, чтобы задать стоимость участия для команд.
+                    </p>
+                  )}
+                </section>
+
+                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <h2 className="text-lg font-semibold text-primary">Финансы игры</h2>
+                    <button
+                      type="button"
+                      onClick={handleAddFinance}
+                      className="px-3 py-2 text-xs font-semibold text-white bg-primary rounded-xl hover:bg-blue-700"
+                    >
+                      Добавить запись
+                    </button>
+                  </div>
+
+                  {(selectedGame.finances ?? []).length > 0 ? (
+                    <div className="space-y-3">
+                      {selectedGame.finances.map((entry) => (
+                        <div
+                          key={entry.id}
+                          className="grid gap-3 md:grid-cols-[1fr_1fr_1fr_auto] items-center p-4 border border-slate-200 rounded-2xl"
+                        >
+                          <select
+                            value={entry.type}
+                            onChange={(event) =>
+                              handleFinanceChange(entry.id, 'type', event.target.value)
+                            }
+                            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          >
+                            <option value="income">Доход</option>
+                            <option value="expense">Расход</option>
+                          </select>
+                          <input
+                            type="number"
+                            min="0"
+                            value={entry.sum}
+                            onChange={(event) =>
+                              handleFinanceChange(entry.id, 'sum', event.target.value)
+                            }
+                            placeholder="Сумма"
+                            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          />
+                          <input
+                            type="date"
+                            value={entry.date ? formatDate(entry.date, true) : ''}
+                            onChange={(event) =>
+                              handleFinanceChange(entry.id, 'date', event.target.value)
+                            }
+                            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveFinance(entry.id)}
+                            className="px-3 py-2 text-xs font-semibold text-rose-600 border border-rose-200 rounded-xl hover:bg-rose-50"
+                          >
+                            Удалить
+                          </button>
+                          <div className="md:col-span-3">
+                            <input
+                              type="text"
+                              value={entry.description}
+                              onChange={(event) =>
+                                handleFinanceChange(entry.id, 'description', event.target.value)
+                              }
+                              placeholder="Комментарий"
+                              className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                            />
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-500">
+                      Пока нет финансовых записей по этой игре. Добавьте доходы и расходы, чтобы контролировать бюджет.
+                    </p>
+                  )}
+
+                  <div className="p-4 bg-slate-50 border border-slate-200 rounded-2xl">
+                    <p className="text-sm text-slate-600">
+                      Доходы: <span className="font-semibold">{currencyFormatter.format(financesSummary.income)}</span>
+                    </p>
+                    <p className="mt-1 text-sm text-slate-600">
+                      Расходы: <span className="font-semibold">{currencyFormatter.format(financesSummary.expense)}</span>
+                    </p>
+                    <p className={`mt-1 text-sm font-semibold ${balanceClass}`}>
+                      Баланс: {currencyFormatter.format(financesSummary.balance)}
+                    </p>
+                  </div>
+                </section>
+
+                <div className="flex flex-col gap-3 md:flex-row md:items-center">
                   <button
                     type="button"
-                    className="inline-flex justify-center px-5 py-3 text-sm font-semibold text-white bg-primary rounded-xl hover:bg-blue-700"
+                    onClick={handleSaveChanges}
+                    disabled={!isDirty || isSaving || !location}
+                    className={`inline-flex justify-center px-5 py-3 text-sm font-semibold text-white rounded-xl transition ${
+                      !isDirty || isSaving || !location
+                        ? 'bg-slate-400 cursor-not-allowed'
+                        : 'bg-primary hover:bg-blue-700'
+                    }`}
                   >
-                    Сохранить изменения
+                    {isSaving ? 'Сохранение…' : 'Сохранить изменения'}
                   </button>
                   <button
                     type="button"
-                    className="inline-flex justify-center px-5 py-3 text-sm font-semibold text-primary border border-primary rounded-xl hover:bg-blue-50"
+                    onClick={handleResetChanges}
+                    disabled={!isDirty}
+                    className={`inline-flex justify-center px-5 py-3 text-sm font-semibold rounded-xl border transition ${
+                      !isDirty
+                        ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                        : 'border-primary text-primary hover:bg-blue-50'
+                    }`}
                   >
-                    Просмотреть предварительно
+                    Отменить изменения
                   </button>
                 </div>
               </div>
@@ -236,6 +1104,67 @@ const GamesPage = () => {
   )
 }
 
+const priceShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  price: PropTypes.number,
+})
+
+const financeShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(['income', 'expense']),
+  sum: PropTypes.number,
+  date: PropTypes.string,
+  description: PropTypes.string,
+})
+
+GamesPage.propTypes = {
+  initialGames: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string,
+      status: PropTypes.string,
+      dateStart: PropTypes.string,
+      type: PropTypes.string,
+      description: PropTypes.string,
+      image: PropTypes.string,
+      startingPlace: PropTypes.string,
+      finishingPlace: PropTypes.string,
+      taskDuration: PropTypes.number,
+      cluesDuration: PropTypes.number,
+      clueEarlyAccessMode: PropTypes.string,
+      clueEarlyPenalty: PropTypes.number,
+      allowCaptainForceClue: PropTypes.bool,
+      allowCaptainFailTask: PropTypes.bool,
+      allowCaptainFinishBreak: PropTypes.bool,
+      breakDuration: PropTypes.number,
+      taskFailurePenalty: PropTypes.number,
+      manyCodesPenalty: PropTypes.arrayOf(PropTypes.number),
+      individualStart: PropTypes.bool,
+      hidden: PropTypes.bool,
+      showCreator: PropTypes.bool,
+      showTasks: PropTypes.bool,
+      hideResult: PropTypes.bool,
+      prices: PropTypes.arrayOf(priceShape),
+      finances: PropTypes.arrayOf(financeShape),
+      teamsCount: PropTypes.number,
+      tasksStats: PropTypes.shape({
+        total: PropTypes.number,
+        bonus: PropTypes.number,
+        canceled: PropTypes.number,
+      }),
+      updatedAt: PropTypes.string,
+      createdAt: PropTypes.string,
+    })
+  ),
+  initialLocation: PropTypes.string,
+}
+
+GamesPage.defaultProps = {
+  initialGames: [],
+  initialLocation: null,
+}
+
 export async function getServerSideProps(context) {
   const session = await getSessionSafe(context)
 
@@ -249,9 +1178,94 @@ export async function getServerSideProps(context) {
     }
   }
 
+  const location = session?.user?.location ?? null
+  let initialGames = []
+
+  if (location) {
+    try {
+      const db = await dbConnect(location)
+
+      if (db) {
+        const GamesModel = db.model('Games')
+        const GamesTeamsModel = db.model('GamesTeams')
+
+        const gamesDocs = await GamesModel.find({})
+          .sort({ updatedAt: -1 })
+          .select({
+            _id: 1,
+            name: 1,
+            status: 1,
+            dateStart: 1,
+            dateStartFact: 1,
+            dateEndFact: 1,
+            type: 1,
+            description: 1,
+            image: 1,
+            startingPlace: 1,
+            finishingPlace: 1,
+            taskDuration: 1,
+            cluesDuration: 1,
+            clueEarlyAccessMode: 1,
+            clueEarlyPenalty: 1,
+            allowCaptainForceClue: 1,
+            allowCaptainFailTask: 1,
+            allowCaptainFinishBreak: 1,
+            breakDuration: 1,
+            taskFailurePenalty: 1,
+            manyCodesPenalty: 1,
+            individualStart: 1,
+            hidden: 1,
+            showCreator: 1,
+            showTasks: 1,
+            hideResult: 1,
+            prices: 1,
+            finances: 1,
+            tasks: 1,
+            updatedAt: 1,
+            createdAt: 1,
+            creatorTelegramId: 1,
+          })
+          .lean()
+
+        const gameIds = gamesDocs
+          .map((game) => (game?._id ? game._id.toString() : null))
+          .filter(Boolean)
+
+        let teamsCountMap = {}
+
+        if (gameIds.length > 0) {
+          const gamesTeams = await GamesTeamsModel.find({ gameId: { $in: gameIds } })
+            .select({ gameId: 1 })
+            .lean()
+
+          teamsCountMap = gamesTeams.reduce((acc, doc) => {
+            if (!doc?.gameId) {
+              return acc
+            }
+
+            const key = doc.gameId
+            acc[key] = (acc[key] ?? 0) + 1
+            return acc
+          }, {})
+        }
+
+        initialGames = gamesDocs.map((game) =>
+          normalizeGameForCabinet({
+            ...game,
+            teamsCount: game?._id ? teamsCountMap[game._id.toString()] ?? 0 : 0,
+          })
+        )
+      }
+    } catch (error) {
+      console.error('Failed to load games for cabinet', error)
+    }
+  }
+
   return {
     props: {
       session,
+      initialGames,
+      initialLocation: location,
     },
   }
 }


### PR DESCRIPTION
## Summary
- подключил дашборд кабинета к MongoDB и вывел реальные статистики и ленту активности
- вынес вспомогательные функции для нормализации игр и отображения относительного времени
- переработал страницу редактирования игр с поддержкой тарифов и финансов, используя данные из базы

## Testing
- npm run build *(fails: Module not found: Can't resolve 'jotai')*


------
https://chatgpt.com/codex/tasks/task_e_68f6790f53288329887a6e19636cc68e