### PR TITLE
Обновить настройки сайта и профиль кабинета

### DIFF
--- a/components/cabinet/CabinetLayout.js
+++ b/components/cabinet/CabinetLayout.js
@@ -32,7 +32,7 @@ const baseMenuItems = [
   { id: 'dashboard', label: 'Обзор', href: '/cabinet', icon: faGaugeHigh },
   { id: 'games', label: 'Игры', href: '/cabinet/games', icon: faGamepad },
   { id: 'teams', label: 'Мои команды', href: '/cabinet/teams', icon: faUsers },
-  { id: 'profile', label: 'Моя анкета', href: '/cabinet/profile', icon: faUser },
+  { id: 'profile', label: 'Мой профиль', href: '/cabinet/profile', icon: faUser },
 ]
 
 const adminMenuItems = [
@@ -113,7 +113,7 @@ const CabinetLayout = ({ children, title, description, activePage }) => {
         }`}
       >
         <div className="flex items-center justify-center h-16 border-b border-slate-200">
-          <span className="text-lg font-semibold text-primary">AQ</span>
+          <span className="text-lg font-semibold text-primary">ActQuest</span>
         </div>
         <nav className="flex-1 py-4 space-y-1 overflow-y-auto">
           {menuItems.map((item) => {

--- a/helpers/formatRelativeTimeFromNow.js
+++ b/helpers/formatRelativeTimeFromNow.js
@@ -1,0 +1,58 @@
+const UNITS = [
+  { unit: 'minute', ms: 60 * 1000, limit: 60 },
+  { unit: 'hour', ms: 60 * 60 * 1000, limit: 24 },
+  { unit: 'day', ms: 24 * 60 * 60 * 1000, limit: 7 },
+  { unit: 'week', ms: 7 * 24 * 60 * 60 * 1000, limit: 4 },
+  { unit: 'month', ms: 30 * 24 * 60 * 60 * 1000, limit: 12 },
+  { unit: 'year', ms: 365 * 24 * 60 * 60 * 1000, limit: Infinity },
+]
+
+const DEFAULT_LOCALE = 'ru'
+const DEFAULT_FALLBACK = '—'
+
+const formatRelativeTimeFromNow = (value, options = {}) => {
+  const { fallback = DEFAULT_FALLBACK, locale = DEFAULT_LOCALE } = options
+
+  if (!value) {
+    return fallback
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return fallback
+  }
+
+  const diffMs = date.getTime() - Date.now()
+  const absDiffMs = Math.abs(diffMs)
+
+  if (absDiffMs < 45 * 1000) {
+    return diffMs <= 0 ? 'только что' : 'через несколько секунд'
+  }
+
+  const hasRelativeTimeFormat =
+    typeof Intl !== 'undefined' && typeof Intl.RelativeTimeFormat === 'function'
+
+  if (!hasRelativeTimeFormat) {
+    try {
+      return date.toLocaleString(locale)
+    } catch (error) {
+      return date.toISOString()
+    }
+  }
+
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
+
+  for (const { unit, ms, limit } of UNITS) {
+    const diff = diffMs / ms
+
+    if (Math.abs(diff) < limit) {
+      return formatter.format(Math.round(diff), unit)
+    }
+  }
+
+  const yearsDiff = diffMs / UNITS[UNITS.length - 1].ms
+  return formatter.format(Math.round(yearsDiff), 'year')
+}
+
+export default formatRelativeTimeFromNow

--- a/helpers/getGameStatusLabel.js
+++ b/helpers/getGameStatusLabel.js
@@ -1,0 +1,18 @@
+const STATUS_LABELS = {
+  active: 'Активна',
+  started: 'Запущена',
+  finished: 'Завершена',
+  canceled: 'Отменена',
+}
+
+const getGameStatusLabel = (status) => {
+  if (!status) {
+    return 'Без статуса'
+  }
+
+  const normalized = typeof status === 'string' ? status.toLowerCase() : String(status)
+
+  return STATUS_LABELS[normalized] ?? 'Неизвестный статус'
+}
+
+export default getGameStatusLabel

--- a/helpers/normalizeGameForCabinet.js
+++ b/helpers/normalizeGameForCabinet.js
@@ -1,0 +1,154 @@
+const ensureString = (value, fallback = '') => {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  if (typeof value.toString === 'function') {
+    const result = value.toString()
+    return result === '[object Object]' ? fallback : result
+  }
+
+  return fallback
+}
+
+const ensureNumber = (value, fallback = 0) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+const ensureBoolean = (value, fallback = false) => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  if (value === 'true') return true
+  if (value === 'false') return false
+
+  return Boolean(value)
+}
+
+const ensureDateISOString = (value) => {
+  if (!value) {
+    return null
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toISOString()
+}
+
+const normalizePrices = (prices = []) => {
+  if (!Array.isArray(prices) || prices.length === 0) {
+    return []
+  }
+
+  return prices.map((price, index) => ({
+    id: ensureString(price?.id, `price-${index}`),
+    name: ensureString(price?.name, ''),
+    price: ensureNumber(price?.price, 0),
+  }))
+}
+
+const normalizeFinances = (finances = []) => {
+  if (!Array.isArray(finances) || finances.length === 0) {
+    return []
+  }
+
+  return finances.map((entry, index) => ({
+    id: ensureString(entry?.id, `finance-${index}`),
+    type: entry?.type === 'expense' ? 'expense' : 'income',
+    sum: ensureNumber(entry?.sum, 0),
+    date: ensureDateISOString(entry?.date),
+    description: ensureString(entry?.description, ''),
+  }))
+}
+
+const normalizeManyCodesPenalty = (value) => {
+  if (!Array.isArray(value) || value.length < 2) {
+    return [0, 0]
+  }
+
+  return [ensureNumber(value[0], 0), ensureNumber(value[1], 0)]
+}
+
+const computeTasksStats = (tasks = []) => {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return { total: 0, bonus: 0, canceled: 0 }
+  }
+
+  return tasks.reduce(
+    (acc, task) => {
+      if (task?.canceled) {
+        acc.canceled += 1
+        return acc
+      }
+
+      if (task?.isBonusTask) {
+        acc.bonus += 1
+      } else {
+        acc.total += 1
+      }
+
+      return acc
+    },
+    { total: 0, bonus: 0, canceled: 0 }
+  )
+}
+
+const normalizeGameForCabinet = (game) => {
+  if (!game) {
+    return null
+  }
+
+  const id = ensureString(game._id ?? game.id)
+  const tasksStats = computeTasksStats(game.tasks)
+
+  return {
+    id,
+    name: ensureString(game.name, ''),
+    status: ensureString(game.status, 'active'),
+    dateStart: ensureDateISOString(game.dateStart),
+    dateStartFact: ensureDateISOString(game.dateStartFact),
+    dateEndFact: ensureDateISOString(game.dateEndFact),
+    type: game?.type === 'photo' ? 'photo' : 'classic',
+    description: ensureString(game.description, ''),
+    image: ensureString(game.image, ''),
+    startingPlace: ensureString(game.startingPlace, ''),
+    finishingPlace: ensureString(game.finishingPlace, ''),
+    taskDuration: ensureNumber(game.taskDuration, 3600),
+    cluesDuration: ensureNumber(game.cluesDuration, 1200),
+    clueEarlyAccessMode: game?.clueEarlyAccessMode === 'penalty' ? 'penalty' : 'time',
+    clueEarlyPenalty: ensureNumber(game.clueEarlyPenalty, 0),
+    allowCaptainForceClue: ensureBoolean(game.allowCaptainForceClue, true),
+    allowCaptainFailTask: ensureBoolean(game.allowCaptainFailTask, true),
+    allowCaptainFinishBreak: ensureBoolean(game.allowCaptainFinishBreak, true),
+    breakDuration: ensureNumber(game.breakDuration, 0),
+    taskFailurePenalty: ensureNumber(game.taskFailurePenalty, 0),
+    manyCodesPenalty: normalizeManyCodesPenalty(game.manyCodesPenalty),
+    individualStart: ensureBoolean(game.individualStart, false),
+    hidden: ensureBoolean(game.hidden, true),
+    showCreator: ensureBoolean(game.showCreator, true),
+    showTasks: ensureBoolean(game.showTasks, false),
+    hideResult: ensureBoolean(game.hideResult, false),
+    prices: normalizePrices(game.prices),
+    finances: normalizeFinances(game.finances),
+    teamsCount: ensureNumber(game.teamsCount, 0),
+    tasksStats,
+    updatedAt: ensureDateISOString(game.updatedAt),
+    createdAt: ensureDateISOString(game.createdAt),
+    creatorTelegramId: ensureString(game.creatorTelegramId, ''),
+  }
+}
+
+export default normalizeGameForCabinet

--- a/helpers/normalizeSiteSettings.js
+++ b/helpers/normalizeSiteSettings.js
@@ -1,0 +1,20 @@
+const toStringOrEmpty = (value) => {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  return String(value)
+}
+
+const normalizeSiteSettings = (doc = null) => {
+  const settings = doc ?? {}
+
+  return {
+    id: settings?._id ? String(settings._id) : null,
+    supportPhone: toStringOrEmpty(settings.supportPhone),
+    announcement: toStringOrEmpty(settings.announcement),
+    chatUrl: toStringOrEmpty(settings.chatUrl),
+  }
+}
+
+export default normalizeSiteSettings

--- a/helpers/normalizeTeamForCabinet.js
+++ b/helpers/normalizeTeamForCabinet.js
@@ -1,0 +1,142 @@
+const ensureString = (value, fallback = '') => {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  if (typeof value === 'number') {
+    return value.toString()
+  }
+
+  if (typeof value.toString === 'function') {
+    const stringValue = value.toString()
+    return stringValue === '[object Object]' ? fallback : stringValue
+  }
+
+  return fallback
+}
+
+const ensureBoolean = (value, fallback = false) => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  if (value === 'true') return true
+  if (value === 'false') return false
+
+  return Boolean(value)
+}
+
+const ensureDateISOString = (value) => {
+  if (!value) {
+    return null
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toISOString()
+}
+
+const ensurePhone = (value) => {
+  const stringValue = ensureString(value, '')
+
+  if (!stringValue) {
+    return ''
+  }
+
+  return stringValue.startsWith('+') ? stringValue : `+${stringValue}`
+}
+
+const normalizeMembers = (members = []) => {
+  if (!Array.isArray(members) || members.length === 0) {
+    return []
+  }
+
+  const normalized = members.map((member, index) => {
+    const role = member?.role === 'capitan' ? 'capitan' : 'participant'
+    const user = member?.user ?? {}
+
+    const rawTelegramId =
+      member?.userTelegramId ??
+      member?.telegramId ??
+      user?.telegramId ??
+      null
+
+    return {
+      id: ensureString(member?.membershipId ?? member?._id ?? member?.id, `member-${index}`),
+      telegramId: ensureString(rawTelegramId, ''),
+      role,
+      isCaptain: role === 'capitan',
+      name: ensureString(user?.name, ''),
+      username: ensureString(user?.username, ''),
+      phone: ensurePhone(user?.phone),
+      userRole: ensureString(user?.role, ''),
+    }
+  })
+
+  return normalized.sort((a, b) => {
+    if (a.isCaptain === b.isCaptain) {
+      return a.name.localeCompare(b.name, 'ru', { sensitivity: 'base' })
+    }
+
+    return a.isCaptain ? -1 : 1
+  })
+}
+
+const normalizeGames = (games = []) => {
+  if (!Array.isArray(games) || games.length === 0) {
+    return []
+  }
+
+  return games
+    .map((game, index) => ({
+      id: ensureString(game?._id ?? game?.id, `game-${index}`),
+      name: ensureString(game?.name, ''),
+      status: ensureString(game?.status, ''),
+      dateStart: ensureDateISOString(game?.dateStart),
+      hidden: ensureBoolean(game?.hidden, false),
+    }))
+    .sort((a, b) => {
+      const dateA = a.dateStart ? new Date(a.dateStart).getTime() : 0
+      const dateB = b.dateStart ? new Date(b.dateStart).getTime() : 0
+      return dateB - dateA
+    })
+}
+
+const normalizeTeamForCabinet = ({ team, members, games }) => {
+  if (!team) {
+    return null
+  }
+
+  const id = ensureString(team?._id ?? team?.id)
+  const normalizedMembers = normalizeMembers(members)
+  const normalizedGames = normalizeGames(games)
+
+  const captain = normalizedMembers.find((member) => member.isCaptain) ?? null
+
+  return {
+    id,
+    name: ensureString(team?.name, ''),
+    description: ensureString(team?.description, ''),
+    open: ensureBoolean(team?.open, true),
+    members: normalizedMembers,
+    membersCount: normalizedMembers.length,
+    captain,
+    games: normalizedGames,
+    gamesCount: normalizedGames.length,
+    createdAt: ensureDateISOString(team?.createdAt),
+    updatedAt: ensureDateISOString(team?.updatedAt),
+  }
+}
+
+export default normalizeTeamForCabinet

--- a/helpers/normalizeUserProfile.js
+++ b/helpers/normalizeUserProfile.js
@@ -1,0 +1,35 @@
+const sanitizeString = (value) => {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  return String(value)
+}
+
+const normalizePreferences = (value) => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((item) => sanitizeString(item).trim())
+    .filter((item) => item.length > 0)
+}
+
+const normalizeUserProfile = (doc = null) => {
+  const profile = doc ?? {}
+
+  const rawPhone = sanitizeString(profile.phone).trim()
+  const phone = rawPhone.length === 0 ? '' : rawPhone.startsWith('+') ? rawPhone : `+${rawPhone}`
+
+  return {
+    id: profile?._id ? String(profile._id) : null,
+    name: sanitizeString(profile.name),
+    username: sanitizeString(profile.username),
+    phone,
+    about: sanitizeString(profile.about),
+    preferences: normalizePreferences(profile.preferences),
+  }
+}
+
+export default normalizeUserProfile

--- a/pages/cabinet/admin.js
+++ b/pages/cabinet/admin.js
@@ -81,36 +81,6 @@ const AdminPage = () => {
           ))}
         </section>
 
-        <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
-          <h3 className="text-lg font-semibold text-primary">Последние запросы на доступ</h3>
-          <p className="mt-1 text-sm text-slate-500">
-            Отслеживайте, какие команды и организаторы запрашивают административные права.
-          </p>
-          <div className="mt-4 space-y-3">
-            {[1, 2, 3].map((index) => (
-              <div key={index} className="p-4 border border-slate-200 rounded-xl">
-                <p className="text-sm font-semibold text-primary">Запрос #{index}</p>
-                <p className="mt-1 text-xs text-slate-500">
-                  Пользователь хочет получить права на управление играми и командами.
-                </p>
-                <div className="flex gap-3 mt-3">
-                  <button
-                    type="button"
-                    className="inline-flex justify-center px-4 py-2 text-xs font-semibold text-white bg-emerald-600 rounded-lg hover:bg-emerald-700"
-                  >
-                    Одобрить
-                  </button>
-                  <button
-                    type="button"
-                    className="inline-flex justify-center px-4 py-2 text-xs font-semibold text-rose-600 border border-rose-200 rounded-lg hover:bg-rose-50"
-                  >
-                    Отклонить
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
       </CabinetLayout>
     </>
   )

--- a/pages/cabinet/games.js
+++ b/pages/cabinet/games.js
@@ -1,80 +1,441 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
 import Head from 'next/head'
+import { useSession } from 'next-auth/react'
+
 import CabinetLayout from '@components/cabinet/CabinetLayout'
 import getSessionSafe from '@helpers/getSessionSafe'
+import formatDate from '@helpers/formatDate'
+import formatDateTime from '@helpers/formatDateTime'
+import formatRelativeTimeFromNow from '@helpers/formatRelativeTimeFromNow'
+import getGameStatusLabel from '@helpers/getGameStatusLabel'
+import normalizeGameForCabinet from '@helpers/normalizeGameForCabinet'
+import { getNounBonusTasks, getNounTasks, getNounTeams } from '@helpers/getNoun'
+import dbConnect from '@utils/dbConnect'
 
-const initialGames = [
-  {
-    id: 'game-1',
-    title: 'Весенний забег',
-    status: 'Черновик',
-    startDate: '2024-04-18',
-    teamsLimit: 12,
-    isPublished: false,
-    description:
-      'Городская игра с заданиями в историческом центре. Включает 5 этапов и финальный пазл.',
-  },
-  {
-    id: 'game-2',
-    title: 'Ночная прогулка',
-    status: 'Опубликована',
-    startDate: '2024-05-04',
-    teamsLimit: 8,
-    isPublished: true,
-    description:
-      'Маршрут по неоновой части города. Задания построены на взаимодействии с подсветкой и витринами.',
-  },
-  {
-    id: 'game-3',
-    title: 'Квест для новичков',
-    status: 'В подготовке',
-    startDate: '2024-05-20',
-    teamsLimit: 16,
-    isPublished: false,
-    description:
-      'Серия из трёх ознакомительных сценариев. Отлично подходит для корпоративных команд.',
-  },
+const GAME_STATUS_OPTIONS = ['active', 'started', 'finished', 'canceled'].map((value) => ({
+  value,
+  label: getGameStatusLabel(value),
+}))
+
+const GAME_TYPE_OPTIONS = [
+  { value: 'classic', label: 'Классика' },
+  { value: 'photo', label: 'Фотоквест' },
 ]
 
-const statusOptions = ['Черновик', 'В подготовке', 'Опубликована', 'Завершена']
+const CLUE_EARLY_MODE_OPTIONS = [
+  { value: 'time', label: 'Добавить время до следующей подсказки' },
+  { value: 'penalty', label: 'Штраф организатора за подсказку' },
+]
 
-const GamesPage = () => {
+const toMinutes = (seconds) => {
+  const numeric = Number(seconds)
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 0
+  }
+  return Math.round(numeric / 60)
+}
+
+const toSeconds = (minutes) => {
+  const numeric = Number(minutes)
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 0
+  }
+  return Math.round(numeric * 60)
+}
+
+const createPrice = () => ({
+  id: `price-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+  name: '',
+  price: 0,
+})
+
+const createFinanceEntry = () => {
+  const now = new Date()
+  return {
+    id: `finance-${now.getTime()}-${Math.random().toString(36).slice(2, 6)}`,
+    type: 'income',
+    sum: 0,
+    date: now.toISOString(),
+    description: '',
+  }
+}
+
+const serializeGameForComparison = (game) => {
+  if (!game) {
+    return null
+  }
+
+  const {
+    id,
+    teamsCount,
+    tasksStats,
+    updatedAt,
+    createdAt,
+    dateStartFact,
+    dateEndFact,
+    ...rest
+  } = game
+
+  const normalizeArray = (array) =>
+    (Array.isArray(array) ? array : [])
+      .map((item) => ({ ...item }))
+      .sort((a, b) => (a.id || '').localeCompare(b.id || ''))
+
+  return JSON.stringify({
+    ...rest,
+    prices: normalizeArray(rest.prices),
+    finances: normalizeArray(rest.finances),
+  })
+}
+
+const buildUpdatePayload = (game) => {
+  const prices = (game.prices ?? []).map((price) => ({
+    id: price.id,
+    name: price.name,
+    price: Number(price.price) || 0,
+  }))
+
+  const finances = (game.finances ?? []).map((entry) => ({
+    id: entry.id,
+    type: entry.type === 'expense' ? 'expense' : 'income',
+    sum: Number(entry.sum) || 0,
+    date: entry.date ? new Date(entry.date).toISOString() : null,
+    description: entry.description,
+  }))
+
+  const manyCodesPenalty = Array.isArray(game.manyCodesPenalty)
+    ? [Number(game.manyCodesPenalty[0]) || 0, Number(game.manyCodesPenalty[1]) || 0]
+    : [0, 0]
+
+  return {
+    name: game.name,
+    status: game.status,
+    dateStart: game.dateStart ? new Date(game.dateStart).toISOString() : null,
+    type: game.type,
+    description: game.description,
+    image: game.image ? game.image : null,
+    startingPlace: game.startingPlace ?? '',
+    finishingPlace: game.finishingPlace ?? '',
+    taskDuration: Number(game.taskDuration) || 0,
+    cluesDuration: Number(game.cluesDuration) || 0,
+    clueEarlyAccessMode: game.clueEarlyAccessMode,
+    clueEarlyPenalty: Number(game.clueEarlyPenalty) || 0,
+    allowCaptainForceClue: Boolean(game.allowCaptainForceClue),
+    allowCaptainFailTask: Boolean(game.allowCaptainFailTask),
+    allowCaptainFinishBreak: Boolean(game.allowCaptainFinishBreak),
+    breakDuration: Number(game.breakDuration) || 0,
+    taskFailurePenalty: Number(game.taskFailurePenalty) || 0,
+    manyCodesPenalty,
+    individualStart: Boolean(game.individualStart),
+    hidden: Boolean(game.hidden),
+    showCreator: Boolean(game.showCreator),
+    showTasks: Boolean(game.showTasks),
+    hideResult: Boolean(game.hideResult),
+    prices,
+    finances,
+  }
+}
+
+const GamesPage = ({ initialGames, initialLocation, session: initialSession }) => {
+  const { data: session } = useSession()
+  const activeSession = session ?? initialSession ?? null
+  const location = activeSession?.user?.location ?? initialLocation ?? null
+  const userRole = activeSession?.user?.role ?? 'client'
+  const currentUserTelegramId = activeSession?.user?.telegramId ?? null
+  const currentUserIdString =
+    currentUserTelegramId === null || currentUserTelegramId === undefined
+      ? null
+      : String(currentUserTelegramId)
+
   const [games, setGames] = useState(initialGames)
-  const [selectedGameId, setSelectedGameId] = useState(initialGames[0].id)
+  const [persistedGames, setPersistedGames] = useState(initialGames)
+  const [selectedGameId, setSelectedGameId] = useState(initialGames[0]?.id ?? null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [feedback, setFeedback] = useState(null)
+
+  useEffect(() => {
+    setGames(initialGames)
+    setPersistedGames(initialGames)
+    setSelectedGameId((prev) => {
+      if (prev && initialGames.some((game) => game.id === prev)) {
+        return prev
+      }
+      return initialGames[0]?.id ?? null
+    })
+  }, [initialGames])
+
+  useEffect(() => {
+    setFeedback(null)
+  }, [selectedGameId])
+
+  const numberFormatter = useMemo(() => new Intl.NumberFormat('ru-RU'), [])
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat('ru-RU', {
+        style: 'currency',
+        currency: 'RUB',
+        maximumFractionDigits: 0,
+      }),
+    []
+  )
 
   const selectedGame = useMemo(
-    () => games.find((game) => game.id === selectedGameId),
+    () => games.find((game) => game.id === selectedGameId) ?? null,
     [games, selectedGameId]
   )
 
-  const updateSelectedGame = (field, value) => {
-    setGames((prevGames) =>
-      prevGames.map((game) =>
-        game.id === selectedGameId
-          ? {
-              ...game,
-              [field]: value,
-            }
-          : game
-      )
-    )
-  }
+  const persistedSelectedGame = useMemo(
+    () => persistedGames.find((game) => game.id === selectedGameId) ?? null,
+    [persistedGames, selectedGameId]
+  )
 
-  const addNewGame = () => {
-    const newGame = {
-      id: `game-${Date.now()}`,
-      title: 'Новая игра',
-      status: 'Черновик',
-      startDate: new Date().toISOString().slice(0, 10),
-      teamsLimit: 10,
-      isPublished: false,
-      description: 'Опишите детали сценария и этапы прохождения.',
+  const isDirty = useMemo(() => {
+    if (!selectedGame || !persistedSelectedGame) {
+      return false
     }
 
-    setGames((prevGames) => [newGame, ...prevGames])
-    setSelectedGameId(newGame.id)
-  }
+    return (
+      serializeGameForComparison(selectedGame) !==
+      serializeGameForComparison(persistedSelectedGame)
+    )
+  }, [persistedSelectedGame, selectedGame])
 
+  const canEditAllGames = userRole === 'admin' || userRole === 'dev'
+  const canEditOwnGames = userRole === 'moder'
+
+  const canEditSelectedGame = useMemo(() => {
+    if (!selectedGame) {
+      return false
+    }
+
+    if (canEditAllGames) {
+      return true
+    }
+
+    if (canEditOwnGames) {
+      if (!currentUserIdString) {
+        return false
+      }
+
+      const creatorId = selectedGame.creatorTelegramId
+      if (!creatorId) {
+        return false
+      }
+
+      return creatorId === currentUserIdString
+    }
+
+    return false
+  }, [canEditAllGames, canEditOwnGames, currentUserIdString, selectedGame])
+
+  const editRestrictionMessage = useMemo(() => {
+    if (!selectedGame || canEditSelectedGame) {
+      return null
+    }
+
+    if (canEditOwnGames) {
+      const creatorId = selectedGame?.creatorTelegramId ?? ''
+      if (currentUserIdString && creatorId && creatorId !== currentUserIdString) {
+        return 'Эта игра создана другим организатором. Модераторы могут редактировать только собственные игры.'
+      }
+    }
+
+    return 'Недостаточно прав для редактирования игры. Обратитесь к администратору.'
+  }, [canEditOwnGames, canEditSelectedGame, currentUserIdString, selectedGame])
+
+  const updateSelectedGame = useCallback(
+    (updater) => {
+      if (!selectedGameId || !canEditSelectedGame) return
+
+      setGames((prevGames) =>
+        prevGames.map((game) => {
+          if (game.id !== selectedGameId) {
+            return game
+          }
+
+          const patch = typeof updater === 'function' ? updater(game) : updater
+          return { ...game, ...patch }
+        })
+      )
+    },
+    [canEditSelectedGame, selectedGameId]
+  )
+
+  const handleResetChanges = useCallback(() => {
+    if (!selectedGameId) return
+
+    setGames((prevGames) =>
+      prevGames.map((game) => {
+        if (game.id !== selectedGameId) {
+          return game
+        }
+
+        const original = persistedGames.find((item) => item.id === selectedGameId)
+        return original ? { ...original } : game
+      })
+    )
+    setFeedback(null)
+  }, [persistedGames, selectedGameId])
+
+  const handleSaveChanges = useCallback(async () => {
+    if (!selectedGame || !location || !canEditSelectedGame) return
+
+    setIsSaving(true)
+    setFeedback(null)
+
+    try {
+      const response = await fetch(`/api/${location}/games/${selectedGame.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: buildUpdatePayload(selectedGame) }),
+      })
+
+      const json = await response.json()
+
+      if (!response.ok || json?.success === false) {
+        throw new Error(json?.error || 'Не удалось сохранить игру')
+      }
+
+      const normalizedGame = normalizeGameForCabinet({
+        ...json.data,
+        teamsCount: selectedGame.teamsCount,
+      })
+
+      setGames((prevGames) =>
+        prevGames.map((game) => (game.id === normalizedGame.id ? normalizedGame : game))
+      )
+      setPersistedGames((prevGames) =>
+        prevGames.map((game) => (game.id === normalizedGame.id ? normalizedGame : game))
+      )
+      setFeedback({ type: 'success', message: 'Изменения сохранены' })
+    } catch (error) {
+      console.error('Failed to update game', error)
+      setFeedback({
+        type: 'error',
+        message: error?.message || 'Не удалось сохранить игру',
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }, [canEditSelectedGame, location, selectedGame])
+
+  const handleAddPrice = useCallback(() => {
+    if (!canEditSelectedGame) return
+    updateSelectedGame((game) => ({
+      prices: [...(game.prices ?? []), createPrice()],
+    }))
+  }, [canEditSelectedGame, updateSelectedGame])
+
+  const handlePriceChange = useCallback(
+    (priceId, field, value) => {
+      if (!canEditSelectedGame) return
+      updateSelectedGame((game) => ({
+        prices: (game.prices ?? []).map((price) =>
+          price.id === priceId
+            ? {
+                ...price,
+                [field]: field === 'price' ? Math.max(0, Number(value) || 0) : value,
+              }
+            : price
+        ),
+      }))
+    },
+    [canEditSelectedGame, updateSelectedGame]
+  )
+
+  const handleRemovePrice = useCallback(
+    (priceId) => {
+      if (!canEditSelectedGame) return
+      updateSelectedGame((game) => ({
+        prices: (game.prices ?? []).filter((price) => price.id !== priceId),
+      }))
+    },
+    [canEditSelectedGame, updateSelectedGame]
+  )
+
+  const handleAddFinance = useCallback(() => {
+    if (!canEditSelectedGame) return
+    updateSelectedGame((game) => ({
+      finances: [...(game.finances ?? []), createFinanceEntry()],
+    }))
+  }, [canEditSelectedGame, updateSelectedGame])
+
+  const handleFinanceChange = useCallback(
+    (financeId, field, value) => {
+      if (!canEditSelectedGame) return
+      updateSelectedGame((game) => ({
+        finances: (game.finances ?? []).map((entry) => {
+          if (entry.id !== financeId) {
+            return entry
+          }
+
+          if (field === 'sum') {
+            return { ...entry, sum: Math.max(0, Number(value) || 0) }
+          }
+
+          if (field === 'date') {
+            return { ...entry, date: value ? new Date(value).toISOString() : null }
+          }
+
+          if (field === 'type') {
+            return { ...entry, type: value === 'expense' ? 'expense' : 'income' }
+          }
+
+        return { ...entry, [field]: value }
+      }),
+    }))
+  },
+    [canEditSelectedGame, updateSelectedGame]
+  )
+
+  const handleRemoveFinance = useCallback(
+    (financeId) => {
+      if (!canEditSelectedGame) return
+      updateSelectedGame((game) => ({
+        finances: (game.finances ?? []).filter((entry) => entry.id !== financeId),
+      }))
+    },
+    [canEditSelectedGame, updateSelectedGame]
+  )
+
+  const tasksSummary = useMemo(() => {
+    if (!selectedGame?.tasksStats) {
+      return null
+    }
+
+    const { total, bonus, canceled } = selectedGame.tasksStats
+    return {
+      total,
+      bonus,
+      canceled,
+      totalLabel: getNounTasks(total),
+      bonusLabel: bonus > 0 ? getNounBonusTasks(bonus) : null,
+      canceledLabel: canceled > 0 ? `${canceled} отменено` : null,
+    }
+  }, [selectedGame])
+
+  const financesSummary = useMemo(() => {
+    if (!selectedGame?.finances) {
+      return { income: 0, expense: 0, balance: 0 }
+    }
+
+    const { income, expense } = selectedGame.finances.reduce(
+      (acc, entry) => {
+        if (entry.type === 'expense') {
+          acc.expense += Number(entry.sum) || 0
+        } else {
+          acc.income += Number(entry.sum) || 0
+        }
+        return acc
+      },
+      { income: 0, expense: 0 }
+    )
+
+    return { income, expense, balance: income - expense }
+  }, [selectedGame])
+
+  const balanceClass = financesSummary.balance >= 0 ? 'text-emerald-600' : 'text-rose-600'
   return (
     <>
       <Head>
@@ -87,142 +448,713 @@ const GamesPage = () => {
       >
         <section className="grid gap-6 md:grid-cols-5">
           <div className="md:col-span-2 space-y-4">
-            <button
-              type="button"
-              onClick={addNewGame}
-              className="flex items-center justify-center w-full px-4 py-3 text-sm font-semibold text-white transition bg-primary rounded-2xl hover:bg-blue-700"
-            >
-              Добавить игру
-            </button>
+            <div className="p-4 bg-white border border-slate-200 rounded-2xl shadow-sm">
+              <p className="text-sm font-semibold text-primary">Ваши игры</p>
+              <p className="mt-1 text-xs text-slate-500">
+                Выберите игру для редактирования основных настроек и финансовой информации.
+              </p>
+            </div>
 
-            <ul className="space-y-3">
-              {games.map((game) => (
-                <li key={game.id}>
-                  <button
-                    type="button"
-                    onClick={() => setSelectedGameId(game.id)}
-                    className={`w-full text-left p-4 border rounded-2xl transition hover:border-primary hover:bg-blue-50 ${
-                      selectedGameId === game.id
-                        ? 'border-primary bg-blue-50 shadow-sm'
-                        : 'border-slate-200 bg-white'
-                    }`}
-                  >
-                    <p className="text-sm font-semibold text-primary">{game.title}</p>
-                    <p className="mt-1 text-xs text-slate-500">{game.status}</p>
-                    <p className="mt-1 text-xs text-slate-400">
-                      Старт: {new Date(game.startDate).toLocaleDateString('ru-RU')}
-                    </p>
-                  </button>
-                </li>
-              ))}
-            </ul>
+            {games.length > 0 ? (
+              <ul className="space-y-3">
+                {games.map((game) => {
+                  const startDateLabel = game.dateStart
+                    ? new Date(game.dateStart).toLocaleString('ru-RU', {
+                        dateStyle: 'short',
+                        timeStyle: 'short',
+                      })
+                    : 'Дата не задана'
+
+                  const relativeUpdatedAt = game.updatedAt
+                    ? formatRelativeTimeFromNow(game.updatedAt)
+                    : '—'
+
+                  return (
+                    <li key={game.id}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedGameId(game.id)}
+                        className={`w-full text-left p-4 border rounded-2xl transition hover:border-primary hover:bg-blue-50 ${
+                          selectedGameId === game.id
+                            ? 'border-primary bg-blue-50 shadow-sm'
+                            : 'border-slate-200 bg-white'
+                        }`}
+                      >
+                        <p className="text-sm font-semibold text-primary">
+                          {game.name || 'Без названия'}
+                        </p>
+                        <p className="mt-1 text-xs text-slate-500">
+                          {getGameStatusLabel(game.status)} · {startDateLabel}
+                        </p>
+                        <p className="mt-1 text-xs text-slate-400">
+                          {getNounTeams(game.teamsCount)} · Обновлено {relativeUpdatedAt}
+                        </p>
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            ) : (
+              <div className="p-6 text-sm text-center text-slate-500 bg-white border border-slate-200 rounded-2xl shadow-sm">
+                Для выбранного города пока нет игр. Создайте сценарий в телеграм-боте, чтобы он появился здесь.
+              </div>
+            )}
           </div>
 
           <div className="md:col-span-3">
             {selectedGame ? (
-              <div className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
-                <div>
-                  <label htmlFor="game-title" className="text-sm font-semibold text-primary">
-                    Название игры
-                  </label>
-                  <input
-                    id="game-title"
-                    type="text"
-                    value={selectedGame.title}
-                    onChange={(event) => updateSelectedGame('title', event.target.value)}
-                    className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                  />
+              <div className="space-y-6">
+                <div className="p-5 bg-white border border-slate-200 rounded-2xl shadow-sm">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span className="px-2.5 py-1 text-xs font-semibold text-primary bg-blue-50 rounded-full">
+                      {getGameStatusLabel(selectedGame.status)}
+                    </span>
+                    <span className="text-xs text-slate-500">
+                      Команд: {numberFormatter.format(selectedGame.teamsCount ?? 0)}
+                    </span>
+                    {selectedGame.updatedAt && (
+                      <span className="text-xs text-slate-500">
+                        Обновлено {formatRelativeTimeFromNow(selectedGame.updatedAt)}
+                      </span>
+                    )}
+                  </div>
+                  {tasksSummary && (
+                    <p className="mt-3 text-sm text-slate-600">
+                      {tasksSummary.totalLabel}
+                      {tasksSummary.bonusLabel ? ` · ${tasksSummary.bonusLabel}` : ''}
+                      {tasksSummary.canceledLabel ? ` · ${tasksSummary.canceledLabel}` : ''}
+                    </p>
+                  )}
                 </div>
 
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div>
-                    <label htmlFor="game-status" className="text-sm font-semibold text-primary">
-                      Статус
-                    </label>
-                    <select
-                      id="game-status"
-                      value={selectedGame.status}
-                      onChange={(event) => updateSelectedGame('status', event.target.value)}
-                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                    >
-                      {statusOptions.map((option) => (
-                        <option key={option} value={option}>
-                          {option}
-                        </option>
-                      ))}
-                    </select>
+                {!location && (
+                  <div className="p-4 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-2xl">
+                    Не удалось определить площадку пользователя. Сохранение изменений недоступно.
+                  </div>
+                )}
+
+                {feedback && (
+                  <div
+                    className={`p-4 text-sm border rounded-2xl ${
+                      feedback.type === 'success'
+                        ? 'bg-emerald-50 border-emerald-200 text-emerald-700'
+                        : 'bg-rose-50 border-rose-200 text-rose-700'
+                    }`}
+                  >
+                    {feedback.message}
+                  </div>
+                )}
+
+                {editRestrictionMessage && (
+                  <div className="p-4 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-2xl">
+                    {editRestrictionMessage}
+                  </div>
+                )}
+
+                <fieldset disabled={!canEditSelectedGame} className="space-y-6 border-0 p-0 m-0">
+                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-title" className="text-sm font-semibold text-primary">
+                        Название игры
+                      </label>
+                      <input
+                        id="game-title"
+                        type="text"
+                        value={selectedGame.name}
+                        onChange={(event) =>
+                          updateSelectedGame({ name: event.target.value })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="game-status" className="text-sm font-semibold text-primary">
+                        Статус
+                      </label>
+                      <select
+                        id="game-status"
+                        value={selectedGame.status}
+                        onChange={(event) =>
+                          updateSelectedGame({ status: event.target.value })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      >
+                        {GAME_STATUS_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
                   </div>
 
-                  <div>
-                    <label htmlFor="game-date" className="text-sm font-semibold text-primary">
-                      Дата старта
-                    </label>
-                    <input
-                      id="game-date"
-                      type="date"
-                      value={selectedGame.startDate}
-                      onChange={(event) => updateSelectedGame('startDate', event.target.value)}
-                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                    />
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-type" className="text-sm font-semibold text-primary">
+                        Тип игры
+                      </label>
+                      <select
+                        id="game-type"
+                        value={selectedGame.type}
+                        onChange={(event) =>
+                          updateSelectedGame({ type: event.target.value })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      >
+                        {GAME_TYPE_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label htmlFor="game-date" className="text-sm font-semibold text-primary">
+                        Плановое начало
+                      </label>
+                      <input
+                        id="game-date"
+                        type="datetime-local"
+                        value={
+                          selectedGame.dateStart
+                            ? formatDateTime(selectedGame.dateStart, true, true)
+                            : ''
+                        }
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            dateStart: event.target.value
+                              ? new Date(event.target.value).toISOString()
+                              : null,
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
                   </div>
-                </div>
 
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div>
-                    <label htmlFor="game-limit" className="text-sm font-semibold text-primary">
-                      Лимит команд
-                    </label>
+                  <div className="flex items-center gap-3">
                     <input
-                      id="game-limit"
-                      type="number"
-                      min="1"
-                      value={selectedGame.teamsLimit}
-                      onChange={(event) => updateSelectedGame('teamsLimit', Number(event.target.value))}
-                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                    />
-                  </div>
-
-                  <div className="flex items-center gap-3 mt-6 md:mt-[34px]">
-                    <input
-                      id="game-published"
+                      id="game-individual-start"
                       type="checkbox"
-                      checked={selectedGame.isPublished}
-                      onChange={(event) => updateSelectedGame('isPublished', event.target.checked)}
-                      className="w-4 h-4 text-primary border-slate-300 rounded focus:ring-primary"
+                      checked={Boolean(selectedGame.individualStart)}
+                      onChange={(event) =>
+                        updateSelectedGame({ individualStart: event.target.checked })
+                      }
+                      className="w-4 h-4 text-primary border-slate-300 rounded"
                     />
-                    <label htmlFor="game-published" className="text-sm text-slate-600">
-                      Игра опубликована
+                    <label htmlFor="game-individual-start" className="text-sm text-slate-600">
+                      Индивидуальный старт для команд
                     </label>
                   </div>
-                </div>
 
-                <div>
-                  <label htmlFor="game-description" className="text-sm font-semibold text-primary">
-                    Описание сценария
-                  </label>
-                  <textarea
-                    id="game-description"
-                    value={selectedGame.description}
-                    onChange={(event) => updateSelectedGame('description', event.target.value)}
-                    rows={6}
-                    className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                  />
-                </div>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-starting-place" className="text-sm font-semibold text-primary">
+                        Место сбора
+                      </label>
+                      <input
+                        id="game-starting-place"
+                        type="text"
+                        value={selectedGame.startingPlace}
+                        onChange={(event) =>
+                          updateSelectedGame({ startingPlace: event.target.value })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="game-finishing-place" className="text-sm font-semibold text-primary">
+                        Место окончания
+                      </label>
+                      <input
+                        id="game-finishing-place"
+                        type="text"
+                        value={selectedGame.finishingPlace}
+                        onChange={(event) =>
+                          updateSelectedGame({ finishingPlace: event.target.value })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                  </div>
 
-                <div className="flex flex-col gap-3 md:flex-row">
-                  <button
-                    type="button"
-                    className="inline-flex justify-center px-5 py-3 text-sm font-semibold text-white bg-primary rounded-xl hover:bg-blue-700"
-                  >
-                    Сохранить изменения
-                  </button>
-                  <button
-                    type="button"
-                    className="inline-flex justify-center px-5 py-3 text-sm font-semibold text-primary border border-primary rounded-xl hover:bg-blue-50"
-                  >
-                    Просмотреть предварительно
-                  </button>
-                </div>
+                  <div>
+                    <label htmlFor="game-description" className="text-sm font-semibold text-primary">
+                      Описание
+                    </label>
+                    <textarea
+                      id="game-description"
+                      value={selectedGame.description}
+                      onChange={(event) =>
+                        updateSelectedGame({ description: event.target.value })
+                      }
+                      rows={5}
+                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                    />
+                  </div>
+
+                  <div>
+                    <label htmlFor="game-image" className="text-sm font-semibold text-primary">
+                      Ссылка на обложку
+                    </label>
+                    <input
+                      id="game-image"
+                      type="text"
+                      value={selectedGame.image}
+                      onChange={(event) =>
+                        updateSelectedGame({ image: event.target.value })
+                      }
+                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                    />
+                    {selectedGame.image && (
+                      <img
+                        src={selectedGame.image}
+                        alt={selectedGame.name || 'Обложка игры'}
+                        className="object-cover w-full h-40 mt-3 rounded-xl border border-slate-200"
+                      />
+                    )}
+                  </div>
+                  </section>
+
+                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <h2 className="text-lg font-semibold text-primary">Настройки заданий и подсказок</h2>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-task-duration" className="text-sm font-semibold text-primary">
+                        Продолжительность задания (мин)
+                      </label>
+                      <input
+                        id="game-task-duration"
+                        type="number"
+                        min="0"
+                        value={toMinutes(selectedGame.taskDuration)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            taskDuration: toSeconds(event.target.value),
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="game-clues-duration" className="text-sm font-semibold text-primary">
+                        Время до подсказки (мин)
+                      </label>
+                      <input
+                        id="game-clues-duration"
+                        type="number"
+                        min="0"
+                        value={toMinutes(selectedGame.cluesDuration)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            cluesDuration: toSeconds(event.target.value),
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                      <p className="mt-1 text-xs text-slate-500">
+                        Укажите 0, чтобы отключить автоматическую выдачу подсказок.
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-clue-mode" className="text-sm font-semibold text-primary">
+                        Режим досрочной подсказки
+                      </label>
+                      <select
+                        id="game-clue-mode"
+                        value={selectedGame.clueEarlyAccessMode}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            clueEarlyAccessMode: event.target.value,
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      >
+                        {CLUE_EARLY_MODE_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label htmlFor="game-clue-penalty" className="text-sm font-semibold text-primary">
+                        {selectedGame.clueEarlyAccessMode === 'penalty'
+                          ? 'Штраф за досрочную подсказку (мин)'
+                          : 'Дополнительное время после подсказки (мин)'}
+                      </label>
+                      <input
+                        id="game-clue-penalty"
+                        type="number"
+                        min="0"
+                        value={toMinutes(selectedGame.clueEarlyPenalty)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            clueEarlyPenalty: toSeconds(event.target.value),
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="game-break-duration" className="text-sm font-semibold text-primary">
+                        Перерыв между заданиями (мин)
+                      </label>
+                      <input
+                        id="game-break-duration"
+                        type="number"
+                        min="0"
+                        value={toMinutes(selectedGame.breakDuration)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            breakDuration: toSeconds(event.target.value),
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="game-task-penalty" className="text-sm font-semibold text-primary">
+                        {selectedGame.type === 'photo'
+                          ? 'Штраф за невыполненное задание (баллы)'
+                          : 'Штраф за невыполненное задание (мин)'}
+                      </label>
+                      <input
+                        id="game-task-penalty"
+                        type="number"
+                        min="0"
+                        value={
+                          selectedGame.type === 'photo'
+                            ? Number(selectedGame.taskFailurePenalty) || 0
+                            : toMinutes(selectedGame.taskFailurePenalty)
+                        }
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            taskFailurePenalty:
+                              selectedGame.type === 'photo'
+                                ? Math.max(0, Number(event.target.value) || 0)
+                                : toSeconds(event.target.value),
+                          })
+                        }
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                  </div>
+
+                  {selectedGame.type !== 'photo' && (
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <div>
+                        <label htmlFor="game-many-codes-limit" className="text-sm font-semibold text-primary">
+                          Лимит неверных кодов для штрафа
+                        </label>
+                        <input
+                          id="game-many-codes-limit"
+                          type="number"
+                          min="0"
+                          value={selectedGame.manyCodesPenalty?.[0] ?? 0}
+                          onChange={(event) =>
+                            updateSelectedGame({
+                              manyCodesPenalty: [
+                                Math.max(0, Number(event.target.value) || 0),
+                                selectedGame.manyCodesPenalty?.[1] ?? 0,
+                              ],
+                            })
+                          }
+                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="game-many-codes-penalty" className="text-sm font-semibold text-primary">
+                          Штраф за превышение лимита (мин)
+                        </label>
+                        <input
+                          id="game-many-codes-penalty"
+                          type="number"
+                          min="0"
+                          value={toMinutes(selectedGame.manyCodesPenalty?.[1] ?? 0)}
+                          onChange={(event) =>
+                            updateSelectedGame({
+                              manyCodesPenalty: [
+                                selectedGame.manyCodesPenalty?.[0] ?? 0,
+                                toSeconds(event.target.value),
+                              ],
+                            })
+                          }
+                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="grid gap-3 md:grid-cols-3">
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.allowCaptainForceClue)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            allowCaptainForceClue: event.target.checked,
+                          })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Досрочные подсказки капитанам
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.allowCaptainFailTask)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            allowCaptainFailTask: event.target.checked,
+                          })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Слив задания капитаном
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.allowCaptainFinishBreak)}
+                        onChange={(event) =>
+                          updateSelectedGame({
+                            allowCaptainFinishBreak: event.target.checked,
+                          })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Досрочное завершение перерыва
+                    </label>
+                  </div>
+                  </section>
+
+                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <h2 className="text-lg font-semibold text-primary">Публикация и результаты</h2>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.hidden)}
+                        onChange={(event) =>
+                          updateSelectedGame({ hidden: event.target.checked })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Игра скрыта из общего списка
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.showCreator)}
+                        onChange={(event) =>
+                          updateSelectedGame({ showCreator: event.target.checked })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Показывать организатора игрокам
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.showTasks)}
+                        onChange={(event) =>
+                          updateSelectedGame({ showTasks: event.target.checked })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Открыть задания после завершения
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(selectedGame.hideResult)}
+                        onChange={(event) =>
+                          updateSelectedGame({ hideResult: event.target.checked })
+                        }
+                        className="w-4 h-4 text-primary border-slate-300 rounded"
+                      />
+                      Скрыть результаты для участников
+                    </label>
+                  </div>
+                  </section>
+
+                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-lg font-semibold text-primary">Стоимость участия</h2>
+                    <button
+                      type="button"
+                      onClick={handleAddPrice}
+                      className="px-3 py-2 text-xs font-semibold text-white bg-primary rounded-xl hover:bg-blue-700"
+                    >
+                      Добавить тариф
+                    </button>
+                  </div>
+
+                  {(selectedGame.prices ?? []).length > 0 ? (
+                    <div className="space-y-3">
+                      {selectedGame.prices.map((price) => (
+                        <div
+                          key={price.id}
+                          className="grid gap-3 md:grid-cols-[2fr_1fr_auto] items-center p-4 border border-slate-200 rounded-2xl"
+                        >
+                          <input
+                            type="text"
+                            value={price.name}
+                            onChange={(event) =>
+                              handlePriceChange(price.id, 'name', event.target.value)
+                            }
+                            placeholder="Название тарифа"
+                            className="w-full px-4 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          />
+                          <input
+                            type="number"
+                            min="0"
+                            value={price.price}
+                            onChange={(event) =>
+                              handlePriceChange(price.id, 'price', event.target.value)
+                            }
+                            placeholder="Стоимость"
+                            className="w-full px-4 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => handleRemovePrice(price.id)}
+                            className="px-3 py-2 text-xs font-semibold text-rose-600 border border-rose-200 rounded-xl hover:bg-rose-50"
+                          >
+                            Удалить
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-500">
+                      Добавьте тариф, чтобы задать стоимость участия для команд.
+                    </p>
+                  )}
+                </section>
+
+                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <h2 className="text-lg font-semibold text-primary">Финансы игры</h2>
+                    <button
+                      type="button"
+                      onClick={handleAddFinance}
+                      className="px-3 py-2 text-xs font-semibold text-white bg-primary rounded-xl hover:bg-blue-700"
+                    >
+                      Добавить запись
+                    </button>
+                  </div>
+
+                  {(selectedGame.finances ?? []).length > 0 ? (
+                    <div className="space-y-3">
+                      {selectedGame.finances.map((entry) => (
+                        <div
+                          key={entry.id}
+                          className="grid gap-3 md:grid-cols-[1fr_1fr_1fr_auto] items-center p-4 border border-slate-200 rounded-2xl"
+                        >
+                          <select
+                            value={entry.type}
+                            onChange={(event) =>
+                              handleFinanceChange(entry.id, 'type', event.target.value)
+                            }
+                            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          >
+                            <option value="income">Доход</option>
+                            <option value="expense">Расход</option>
+                          </select>
+                          <input
+                            type="number"
+                            min="0"
+                            value={entry.sum}
+                            onChange={(event) =>
+                              handleFinanceChange(entry.id, 'sum', event.target.value)
+                            }
+                            placeholder="Сумма"
+                            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          />
+                          <input
+                            type="date"
+                            value={entry.date ? formatDate(entry.date, true) : ''}
+                            onChange={(event) =>
+                              handleFinanceChange(entry.id, 'date', event.target.value)
+                            }
+                            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveFinance(entry.id)}
+                            className="px-3 py-2 text-xs font-semibold text-rose-600 border border-rose-200 rounded-xl hover:bg-rose-50"
+                          >
+                            Удалить
+                          </button>
+                          <div className="md:col-span-3">
+                            <input
+                              type="text"
+                              value={entry.description}
+                              onChange={(event) =>
+                                handleFinanceChange(entry.id, 'description', event.target.value)
+                              }
+                              placeholder="Комментарий"
+                              className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                            />
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-500">
+                      Пока нет финансовых записей по этой игре. Добавьте доходы и расходы, чтобы контролировать бюджет.
+                    </p>
+                  )}
+
+                  <div className="p-4 bg-slate-50 border border-slate-200 rounded-2xl">
+                    <p className="text-sm text-slate-600">
+                      Доходы: <span className="font-semibold">{currencyFormatter.format(financesSummary.income)}</span>
+                    </p>
+                    <p className="mt-1 text-sm text-slate-600">
+                      Расходы: <span className="font-semibold">{currencyFormatter.format(financesSummary.expense)}</span>
+                    </p>
+                    <p className={`mt-1 text-sm font-semibold ${balanceClass}`}>
+                      Баланс: {currencyFormatter.format(financesSummary.balance)}
+                    </p>
+                  </div>
+                  </section>
+
+                  <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                    <button
+                      type="button"
+                      onClick={handleSaveChanges}
+                      disabled={!canEditSelectedGame || !isDirty || isSaving || !location}
+                      className={`inline-flex justify-center px-5 py-3 text-sm font-semibold text-white rounded-xl transition ${
+                        !canEditSelectedGame || !isDirty || isSaving || !location
+                          ? 'bg-slate-400 cursor-not-allowed'
+                          : 'bg-primary hover:bg-blue-700'
+                      }`}
+                    >
+                      {isSaving ? 'Сохранение…' : 'Сохранить изменения'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleResetChanges}
+                      disabled={!canEditSelectedGame || !isDirty}
+                      className={`inline-flex justify-center px-5 py-3 text-sm font-semibold rounded-xl border transition ${
+                        !canEditSelectedGame || !isDirty
+                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                          : 'border-primary text-primary hover:bg-blue-50'
+                      }`}
+                    >
+                      Отменить изменения
+                    </button>
+                  </div>
+                </fieldset>
               </div>
             ) : (
               <div className="flex items-center justify-center h-full p-6 bg-white border border-dashed rounded-2xl border-slate-200">
@@ -234,6 +1166,69 @@ const GamesPage = () => {
       </CabinetLayout>
     </>
   )
+}
+
+const priceShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  price: PropTypes.number,
+})
+
+const financeShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(['income', 'expense']),
+  sum: PropTypes.number,
+  date: PropTypes.string,
+  description: PropTypes.string,
+})
+
+GamesPage.propTypes = {
+  initialGames: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string,
+      status: PropTypes.string,
+      dateStart: PropTypes.string,
+      type: PropTypes.string,
+      description: PropTypes.string,
+      image: PropTypes.string,
+      startingPlace: PropTypes.string,
+      finishingPlace: PropTypes.string,
+      taskDuration: PropTypes.number,
+      cluesDuration: PropTypes.number,
+      clueEarlyAccessMode: PropTypes.string,
+      clueEarlyPenalty: PropTypes.number,
+      allowCaptainForceClue: PropTypes.bool,
+      allowCaptainFailTask: PropTypes.bool,
+      allowCaptainFinishBreak: PropTypes.bool,
+      breakDuration: PropTypes.number,
+      taskFailurePenalty: PropTypes.number,
+      manyCodesPenalty: PropTypes.arrayOf(PropTypes.number),
+      individualStart: PropTypes.bool,
+      hidden: PropTypes.bool,
+      showCreator: PropTypes.bool,
+      showTasks: PropTypes.bool,
+      hideResult: PropTypes.bool,
+      prices: PropTypes.arrayOf(priceShape),
+      finances: PropTypes.arrayOf(financeShape),
+      teamsCount: PropTypes.number,
+      tasksStats: PropTypes.shape({
+        total: PropTypes.number,
+        bonus: PropTypes.number,
+        canceled: PropTypes.number,
+      }),
+      updatedAt: PropTypes.string,
+      createdAt: PropTypes.string,
+    })
+  ),
+  initialLocation: PropTypes.string,
+  session: PropTypes.object,
+}
+
+GamesPage.defaultProps = {
+  initialGames: [],
+  initialLocation: null,
+  session: null,
 }
 
 export async function getServerSideProps(context) {
@@ -249,9 +1244,110 @@ export async function getServerSideProps(context) {
     }
   }
 
+  const location = session?.user?.location ?? null
+  const userRole = session?.user?.role ?? 'client'
+  const rawTelegramId = session?.user?.telegramId
+  const numericTelegramId =
+    rawTelegramId === null || rawTelegramId === undefined
+      ? null
+      : Number(rawTelegramId)
+  const creatorTelegramId = Number.isFinite(numericTelegramId)
+    ? numericTelegramId
+    : null
+  let initialGames = []
+
+  if (location) {
+    try {
+      const db = await dbConnect(location)
+
+      if (db) {
+        const GamesModel = db.model('Games')
+        const GamesTeamsModel = db.model('GamesTeams')
+
+        const canLoadAllGames = userRole === 'admin' || userRole === 'dev'
+        const canLoadOwnGames = userRole === 'moder' && creatorTelegramId !== null
+
+        if (canLoadAllGames || canLoadOwnGames) {
+          const query = canLoadAllGames ? {} : { creatorTelegramId }
+
+          const gamesDocs = await GamesModel.find(query)
+            .sort({ updatedAt: -1 })
+            .select({
+              _id: 1,
+              name: 1,
+              status: 1,
+              dateStart: 1,
+              dateStartFact: 1,
+              dateEndFact: 1,
+              type: 1,
+              description: 1,
+              image: 1,
+              startingPlace: 1,
+              finishingPlace: 1,
+              taskDuration: 1,
+              cluesDuration: 1,
+              clueEarlyAccessMode: 1,
+              clueEarlyPenalty: 1,
+              allowCaptainForceClue: 1,
+              allowCaptainFailTask: 1,
+              allowCaptainFinishBreak: 1,
+              breakDuration: 1,
+              taskFailurePenalty: 1,
+              manyCodesPenalty: 1,
+              individualStart: 1,
+              hidden: 1,
+              showCreator: 1,
+              showTasks: 1,
+              hideResult: 1,
+              prices: 1,
+              finances: 1,
+              tasks: 1,
+              updatedAt: 1,
+              createdAt: 1,
+              creatorTelegramId: 1,
+            })
+            .lean()
+
+          const gameIds = gamesDocs
+            .map((game) => (game?._id ? game._id.toString() : null))
+            .filter(Boolean)
+
+          let teamsCountMap = {}
+
+          if (gameIds.length > 0) {
+            const gamesTeams = await GamesTeamsModel.find({ gameId: { $in: gameIds } })
+              .select({ gameId: 1 })
+              .lean()
+
+            teamsCountMap = gamesTeams.reduce((acc, doc) => {
+              if (!doc?.gameId) {
+                return acc
+              }
+
+              const key = doc.gameId
+              acc[key] = (acc[key] ?? 0) + 1
+              return acc
+            }, {})
+          }
+
+          initialGames = gamesDocs.map((game) =>
+            normalizeGameForCabinet({
+              ...game,
+              teamsCount: game?._id ? teamsCountMap[game._id.toString()] ?? 0 : 0,
+            })
+          )
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load games for cabinet', error)
+    }
+  }
+
   return {
     props: {
       session,
+      initialGames,
+      initialLocation: location,
     },
   }
 }

--- a/pages/cabinet/index.js
+++ b/pages/cabinet/index.js
@@ -1,10 +1,15 @@
 import Head from 'next/head'
-import { useMemo } from 'react'
+import PropTypes from 'prop-types'
+import { useCallback, useMemo } from 'react'
 import { useSession } from 'next-auth/react'
 
 import CabinetLayout from '@components/cabinet/CabinetLayout'
 import getSessionSafe from '@helpers/getSessionSafe'
 import { resolveCabinetCallback } from '@helpers/cabinetAuth'
+import formatRelativeTimeFromNow from '@helpers/formatRelativeTimeFromNow'
+import getGameStatusLabel from '@helpers/getGameStatusLabel'
+import { getNounTeams, getNounUsers } from '@helpers/getNoun'
+import dbConnect from '@utils/dbConnect'
 
 const quickActions = [
   {
@@ -23,67 +28,107 @@ const quickActions = [
   },
   {
     id: 'update-profile',
-    title: 'Обновить анкету',
+    title: 'Обновить профиль',
     description:
       'Укажите актуальные контакты и роль в проекте, чтобы коллеги могли вас найти.',
     href: '/cabinet/profile',
   },
 ]
 
-const activityFeed = [
-  {
-    id: 'activity-1',
-    title: 'Команда «Северный свет» добавлена',
-    time: '5 минут назад',
-    category: 'Команды',
-  },
-  {
-    id: 'activity-2',
-    title: 'Игра «Осенний марафон» опубликована',
-    time: '2 часа назад',
-    category: 'Игры',
-  },
-  {
-    id: 'activity-3',
-    title: 'Обновлены контактные данные организатора',
-    time: 'вчера',
-    category: 'Профиль',
-  },
-]
-
-const statsConfig = [
-  {
-    id: 'games',
-    title: 'Активные игры',
-    value: 4,
-    delta: '+2 за неделю',
-  },
-  {
-    id: 'teams',
-    title: 'Команд участвует',
-    value: 18,
-    delta: '+5 новых',
-  },
-  {
-    id: 'players',
-    title: 'Игроков задействовано',
-    value: 112,
-    delta: 'стабильно',
-  },
-]
-
-const CabinetDashboard = ({ session: initialSession }) => {
+const CabinetDashboard = ({
+  session: initialSession,
+  stats: initialStats,
+  activity: initialActivity,
+}) => {
   const { data: session, status } = useSession()
   const activeSession = session ?? initialSession ?? null
 
+  const numberFormatter = useMemo(() => new Intl.NumberFormat('ru-RU'), [])
+  const stats = initialStats ?? { activeGames: 0, teams: 0, players: 0 }
+
   const normalizedStats = useMemo(
-    () =>
-      statsConfig.map((item) => ({
-        ...item,
-        value: new Intl.NumberFormat('ru-RU').format(item.value),
-      })),
-    []
+    () => [
+      {
+        id: 'games',
+        title: 'Активные игры',
+        value: numberFormatter.format(stats.activeGames ?? 0),
+        description: 'Статусы «активна» и «запущена» по выбранному городу.',
+      },
+      {
+        id: 'teams',
+        title: 'Команд участвует',
+        value: numberFormatter.format(stats.teams ?? 0),
+        description: 'Всего зарегистрированных команд.',
+      },
+      {
+        id: 'players',
+        title: 'Игроков задействовано',
+        value: numberFormatter.format(stats.players ?? 0),
+        description: 'Количество участников, привязанных к командам.',
+      },
+    ],
+    [numberFormatter, stats]
   )
+
+  const buildGameDetails = useCallback((item) => {
+    const parts = []
+
+    if (item.status) {
+      parts.push(`Статус: ${getGameStatusLabel(item.status)}`)
+    }
+
+    if (typeof item.teamsCount === 'number' && item.teamsCount >= 0) {
+      parts.push(getNounTeams(item.teamsCount))
+    }
+
+    if (item.hidden) {
+      parts.push('Скрыта из списка')
+    }
+
+    return parts.length > 0 ? parts.join(' · ') : 'Изменение параметров игры'
+  }, [])
+
+  const buildTeamDetails = useCallback((item) => {
+    const parts = []
+
+    if (typeof item.membersCount === 'number' && item.membersCount >= 0) {
+      parts.push(getNounUsers(item.membersCount))
+    }
+
+    return parts.length > 0 ? parts.join(' · ') : 'Обновление карточки команды'
+  }, [])
+
+  const activityItems = useMemo(() => {
+    if (!Array.isArray(initialActivity)) {
+      return []
+    }
+
+    return initialActivity.map((item) => {
+      const timestamp = item.timestamp ?? null
+      const relativeTime = timestamp
+        ? formatRelativeTimeFromNow(timestamp)
+        : '—'
+      const absoluteTime = timestamp
+        ? new Date(timestamp).toLocaleString('ru-RU')
+        : undefined
+
+      const isGame = item.type === 'game'
+      const title = isGame
+        ? `Игра «${item.name || 'Без названия'}» обновлена`
+        : `Команда «${item.name || 'Без названия'}» обновлена`
+
+      const details = isGame ? buildGameDetails(item) : buildTeamDetails(item)
+
+      return {
+        id: item.id,
+        title,
+        category: isGame ? 'Игры' : 'Команды',
+        relativeTime,
+        absoluteTime,
+        details,
+      }
+    })
+  }, [buildGameDetails, buildTeamDetails, initialActivity])
 
   if (!activeSession) {
     if (status === 'loading') {
@@ -106,8 +151,8 @@ const CabinetDashboard = ({ session: initialSession }) => {
           </p>
           <a
             href="/cabinet/login"
-            className="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold text-slate-900 bg-white rounded-xl"
-          >
+          className="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold text-slate-900 bg-white rounded-xl"
+        >
             Перейти к авторизации
           </a>
         </div>
@@ -133,7 +178,7 @@ const CabinetDashboard = ({ session: initialSession }) => {
             >
               <p className="text-sm font-medium text-slate-500">{stat.title}</p>
               <p className="mt-3 text-3xl font-semibold text-primary">{stat.value}</p>
-              <p className="mt-2 text-xs font-medium text-emerald-600">{stat.delta}</p>
+              <p className="mt-2 text-xs font-medium text-slate-500">{stat.description}</p>
             </article>
           ))}
         </section>
@@ -160,15 +205,22 @@ const CabinetDashboard = ({ session: initialSession }) => {
               Последние изменения, которые произошли в вашем кабинете.
             </p>
             <ul className="mt-4 space-y-4">
-              {activityFeed.map((item) => (
-                <li key={item.id} className="p-4 bg-slate-50 rounded-xl">
-                  <p className="text-sm font-semibold text-primary">{item.title}</p>
-                  <div className="flex items-center justify-between mt-2 text-xs text-slate-500">
-                    <span>{item.category}</span>
-                    <span>{item.time}</span>
-                  </div>
+              {activityItems.length > 0 ? (
+                activityItems.map((item) => (
+                  <li key={item.id} className="p-4 bg-slate-50 rounded-xl">
+                    <p className="text-sm font-semibold text-primary">{item.title}</p>
+                    <p className="mt-2 text-xs text-slate-500">{item.details}</p>
+                    <div className="flex items-center justify-between mt-3 text-xs text-slate-500">
+                      <span>{item.category}</span>
+                      <span title={item.absoluteTime}>{item.relativeTime}</span>
+                    </div>
+                  </li>
+                ))
+              ) : (
+                <li className="p-4 bg-slate-50 rounded-xl">
+                  <p className="text-sm text-slate-500">Недавняя активность не найдена.</p>
                 </li>
-              ))}
+              )}
             </ul>
           </div>
         </section>
@@ -198,6 +250,33 @@ const CabinetDashboard = ({ session: initialSession }) => {
   )
 }
 
+CabinetDashboard.propTypes = {
+  session: PropTypes.object,
+  stats: PropTypes.shape({
+    activeGames: PropTypes.number,
+    teams: PropTypes.number,
+    players: PropTypes.number,
+  }),
+  activity: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      type: PropTypes.string,
+      name: PropTypes.string,
+      status: PropTypes.string,
+      hidden: PropTypes.bool,
+      teamsCount: PropTypes.number,
+      membersCount: PropTypes.number,
+      timestamp: PropTypes.string,
+    })
+  ),
+}
+
+CabinetDashboard.defaultProps = {
+  session: null,
+  stats: { activeGames: 0, teams: 0, players: 0 },
+  activity: [],
+}
+
 export async function getServerSideProps(context) {
   const session = await getSessionSafe(context)
   const { relativeCallback, isSafe } = resolveCabinetCallback(context?.query?.callbackUrl, context?.req)
@@ -223,9 +302,140 @@ export async function getServerSideProps(context) {
     }
   }
 
+  const location = session?.user?.location ?? null
+  let stats = { activeGames: 0, teams: 0, players: 0 }
+  let activity = []
+
+  if (location) {
+    try {
+      const db = await dbConnect(location)
+
+      if (db) {
+        const GamesModel = db.model('Games')
+        const TeamsModel = db.model('Teams')
+        const TeamsUsersModel = db.model('TeamsUsers')
+        const GamesTeamsModel = db.model('GamesTeams')
+
+        const [activeGamesCount, totalTeamsCount, totalPlayersCount, recentGames, recentTeams] =
+          await Promise.all([
+            GamesModel.countDocuments({ status: { $in: ['active', 'started'] } }),
+            TeamsModel.countDocuments({}),
+            TeamsUsersModel.countDocuments({}),
+            GamesModel.find({})
+              .sort({ updatedAt: -1 })
+              .limit(5)
+              .select({
+                _id: 1,
+                name: 1,
+                status: 1,
+                hidden: 1,
+                updatedAt: 1,
+                createdAt: 1,
+              })
+              .lean(),
+            TeamsModel.find({})
+              .sort({ updatedAt: -1 })
+              .limit(5)
+              .select({ _id: 1, name: 1, updatedAt: 1, createdAt: 1 })
+              .lean(),
+          ])
+
+        stats = {
+          activeGames: activeGamesCount,
+          teams: totalTeamsCount,
+          players: totalPlayersCount,
+        }
+
+        const gameIds = recentGames
+          .map((game) => (game?._id ? game._id.toString() : null))
+          .filter(Boolean)
+
+        let teamsCountMap = {}
+
+        if (gameIds.length > 0) {
+          const gamesTeams = await GamesTeamsModel.find({ gameId: { $in: gameIds } })
+            .select({ gameId: 1 })
+            .lean()
+
+          teamsCountMap = gamesTeams.reduce((acc, doc) => {
+            if (!doc?.gameId) {
+              return acc
+            }
+
+            const key = doc.gameId
+            acc[key] = (acc[key] ?? 0) + 1
+            return acc
+          }, {})
+        }
+
+        const teamIds = recentTeams
+          .map((team) => (team?._id ? team._id.toString() : null))
+          .filter(Boolean)
+
+        let membersCountMap = {}
+
+        if (teamIds.length > 0) {
+          const teamMembers = await TeamsUsersModel.find({ teamId: { $in: teamIds } })
+            .select({ teamId: 1 })
+            .lean()
+
+          membersCountMap = teamMembers.reduce((acc, doc) => {
+            if (!doc?.teamId) {
+              return acc
+            }
+
+            const key = doc.teamId
+            acc[key] = (acc[key] ?? 0) + 1
+            return acc
+          }, {})
+        }
+
+        const gamesActivity = recentGames.map((game) => {
+          const idString = game?._id ? game._id.toString() : null
+          const timestamp = game?.updatedAt ?? game?.createdAt ?? null
+
+          return {
+            id: `game-${idString ?? Math.random().toString(36).slice(2)}`,
+            type: 'game',
+            name: game?.name ?? 'Без названия',
+            status: game?.status ?? null,
+            hidden: Boolean(game?.hidden),
+            teamsCount: idString ? teamsCountMap[idString] ?? 0 : 0,
+            timestamp: timestamp ? new Date(timestamp).toISOString() : null,
+          }
+        })
+
+        const teamsActivity = recentTeams.map((team) => {
+          const idString = team?._id ? team._id.toString() : null
+          const timestamp = team?.updatedAt ?? team?.createdAt ?? null
+
+          return {
+            id: `team-${idString ?? Math.random().toString(36).slice(2)}`,
+            type: 'team',
+            name: team?.name ?? 'Без названия',
+            membersCount: idString ? membersCountMap[idString] ?? 0 : 0,
+            timestamp: timestamp ? new Date(timestamp).toISOString() : null,
+          }
+        })
+
+        activity = [...gamesActivity, ...teamsActivity]
+          .filter((item) => item.timestamp)
+          .sort(
+            (a, b) =>
+              new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+          )
+          .slice(0, 8)
+      }
+    } catch (error) {
+      console.error('Failed to load cabinet dashboard data', error)
+    }
+  }
+
   return {
     props: {
       session,
+      stats,
+      activity,
     },
   }
 }

--- a/pages/cabinet/login.js
+++ b/pages/cabinet/login.js
@@ -212,17 +212,14 @@ const CabinetLoginPage = ({ authCallbackUrl, authCallbackSource }) => {
   )
 
   const handleTestLogin = useCallback(() => {
-    if (!isTestAuthEnabled) return
+    if (!isTestAuthEnabled || isAuthenticating) return
 
     handleTelegramAuth({
       id: '261102161',
-      first_name: 'ActQuest',
-      last_name: 'Tester',
-      username: 'actquest_tester',
       __isTestAuth: true,
       __testLocation: location,
     })
-  }, [handleTelegramAuth, location])
+  }, [handleTelegramAuth, isAuthenticating, location])
 
   useEffect(() => {
     if (!isClient) return undefined

--- a/pages/cabinet/profile.js
+++ b/pages/cabinet/profile.js
@@ -1,22 +1,36 @@
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
+import PropTypes from 'prop-types'
 import Head from 'next/head'
 import { useSession } from 'next-auth/react'
+
 import CabinetLayout from '@components/cabinet/CabinetLayout'
 import getSessionSafe from '@helpers/getSessionSafe'
+import normalizeUserProfile from '@helpers/normalizeUserProfile'
+import dbConnect from '@utils/dbConnect'
 
-const ProfilePage = () => {
+const preferenceOptions = [
+  'Городские квесты',
+  'Настольные сценарии',
+  'Корпоративные игры',
+  'Командные задания',
+]
+
+const ProfilePage = ({ initialProfile }) => {
   const { data: session } = useSession()
-  const [formState, setFormState] = useState({
-    name: session?.user?.name || '',
-    username: session?.user?.username || '',
-    email: '',
-    phone: '',
-    about: 'Расскажите о своём опыте и любимых форматах квестов.',
-    preferences: ['Городские квесты', 'Командные задания'],
-  })
-  const [isSaved, setIsSaved] = useState(false)
+  const [formState, setFormState] = useState(() => initialProfile)
+  const [saveState, setSaveState] = useState({ isSaving: false, isSaved: false, error: null })
 
-  const togglePreference = (preference) => {
+  useEffect(() => {
+    setFormState(initialProfile)
+    setSaveState({ isSaving: false, isSaved: false, error: null })
+  }, [initialProfile])
+
+  const handleChange = useCallback((field, value) => {
+    setFormState((prevState) => ({ ...prevState, [field]: value }))
+    setSaveState((prevState) => ({ ...prevState, isSaved: false, error: null }))
+  }, [])
+
+  const togglePreference = useCallback((preference) => {
     setFormState((prevState) => {
       const hasPreference = prevState.preferences.includes(preference)
 
@@ -27,26 +41,105 @@ const ProfilePage = () => {
           : [...prevState.preferences, preference],
       }
     })
-  }
+    setSaveState((prevState) => ({ ...prevState, isSaved: false, error: null }))
+  }, [])
 
-  const handleChange = (field, value) => {
-    setFormState((prevState) => ({ ...prevState, [field]: value }))
-    setIsSaved(false)
-  }
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault()
 
-  const handleSubmit = (event) => {
-    event.preventDefault()
-    setIsSaved(true)
-  }
+      const location = session?.user?.location ?? null
+      const profileId = formState.id ?? null
+
+      if (!location || !profileId) {
+        setSaveState({
+          isSaving: false,
+          isSaved: false,
+          error: 'Не удалось определить пользователя для обновления профиля.',
+        })
+        return
+      }
+
+      setSaveState({ isSaving: true, isSaved: false, error: null })
+
+      const normalizeText = (value) => (typeof value === 'string' ? value.trim() : '')
+      const normalizeNullable = (value) => {
+        const normalized = normalizeText(value)
+        return normalized.length > 0 ? normalized : null
+      }
+      const normalizePhone = (value) => {
+        if (typeof value !== 'string') {
+          return null
+        }
+
+        const digits = value.replace(/\D/g, '')
+        return digits.length > 0 ? Number(digits) : null
+      }
+
+      const payload = {
+        name: normalizeText(formState.name),
+        username: normalizeNullable(formState.username),
+        phone: normalizePhone(formState.phone),
+        about: normalizeText(formState.about),
+        preferences: Array.isArray(formState.preferences)
+          ? Array.from(
+              new Set(
+                formState.preferences
+                  .map((item) => normalizeText(item))
+                  .filter((item) => item.length > 0)
+              )
+            )
+          : [],
+      }
+
+      try {
+        const response = await fetch(
+          `/api/${location}/custom?collection=users&id=${profileId}`,
+          {
+            method: 'PUT',
+            headers: {
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ data: payload }),
+          }
+        )
+
+        if (!response.ok) {
+          const errorText = await response.text()
+          throw new Error(errorText || 'Unknown error')
+        }
+
+        const json = await response.json()
+
+        if (!json?.success) {
+          throw new Error('Не удалось сохранить изменения')
+        }
+
+        const normalized = normalizeUserProfile(json.data)
+
+        setFormState(normalized)
+        setSaveState({ isSaving: false, isSaved: true, error: null })
+      } catch (error) {
+        console.error('Failed to update profile', error)
+        setSaveState({
+          isSaving: false,
+          isSaved: false,
+          error: 'Не удалось сохранить профиль. Попробуйте ещё раз.',
+        })
+      }
+    },
+    [formState, session]
+  )
 
   return (
     <>
       <Head>
-        <title>ActQuest — Моя анкета</title>
+        <title>ActQuest — Мой профиль</title>
       </Head>
       <CabinetLayout
-        title="Моя анкета"
-        description="Заполните профиль, чтобы коллеги и участники знали, как с вами связаться."
+        title="Мой профиль"
+        description="Обновите контакты, чтобы участники и коллеги могли быстро связаться с вами."
         activePage="profile"
       >
         <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
@@ -72,41 +165,26 @@ const ProfilePage = () => {
                 <input
                   id="profile-username"
                   type="text"
-                  value={formState.username}
+                  value={formState.username ?? ''}
                   onChange={(event) => handleChange('username', event.target.value)}
                   className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                  placeholder="Например, quest_master"
                 />
               </div>
             </div>
 
-            <div className="grid gap-4 md:grid-cols-2">
-              <div>
-                <label htmlFor="profile-email" className="text-sm font-semibold text-primary">
-                  Электронная почта
-                </label>
-                <input
-                  id="profile-email"
-                  type="email"
-                  value={formState.email}
-                  onChange={(event) => handleChange('email', event.target.value)}
-                  className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                  placeholder="name@example.com"
-                />
-              </div>
-
-              <div>
-                <label htmlFor="profile-phone" className="text-sm font-semibold text-primary">
-                  Телефон
-                </label>
-                <input
-                  id="profile-phone"
-                  type="tel"
-                  value={formState.phone}
-                  onChange={(event) => handleChange('phone', event.target.value)}
-                  className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                  placeholder="+7 000 000-00-00"
-                />
-              </div>
+            <div>
+              <label htmlFor="profile-phone" className="text-sm font-semibold text-primary">
+                Телефон
+              </label>
+              <input
+                id="profile-phone"
+                type="tel"
+                value={formState.phone}
+                onChange={(event) => handleChange('phone', event.target.value)}
+                className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                placeholder="+7 900 000-00-00"
+              />
             </div>
 
             <div>
@@ -119,44 +197,59 @@ const ProfilePage = () => {
                 onChange={(event) => handleChange('about', event.target.value)}
                 rows={5}
                 className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                placeholder="Расскажите об опыте, любимых форматах и роли в команде."
               />
             </div>
 
             <div>
               <p className="text-sm font-semibold text-primary">Предпочитаемые форматы</p>
               <div className="flex flex-wrap gap-3 mt-3">
-                {['Городские квесты', 'Настольные сценарии', 'Корпоративные игры', 'Командные задания'].map(
-                  (preference) => {
-                    const isActive = formState.preferences.includes(preference)
+                {preferenceOptions.map((preference) => {
+                  const isActive = formState.preferences.includes(preference)
 
-                    return (
-                      <button
-                        key={preference}
-                        type="button"
-                        onClick={() => togglePreference(preference)}
-                        className={`px-4 py-2 text-sm font-semibold rounded-xl transition ${
-                          isActive
-                            ? 'text-white bg-primary shadow-sm'
-                            : 'text-slate-600 border border-slate-200 hover:border-primary hover:text-primary'
-                        }`}
-                      >
-                        {preference}
-                      </button>
-                    )
-                  }
-                )}
+                  return (
+                    <button
+                      key={preference}
+                      type="button"
+                      onClick={() => togglePreference(preference)}
+                      className={`px-4 py-2 text-sm font-semibold rounded-xl transition ${
+                        isActive
+                          ? 'text-white bg-primary shadow-sm'
+                          : 'text-slate-600 border border-slate-200 hover:border-primary hover:text-primary'
+                      }`}
+                    >
+                      {preference}
+                    </button>
+                  )
+                })}
               </div>
             </div>
+
+            {saveState.error ? (
+              <div className="px-4 py-3 text-sm text-rose-600 bg-rose-50 border border-rose-200 rounded-xl">
+                {saveState.error}
+              </div>
+            ) : null}
+            {saveState.isSaved ? (
+              <div className="px-4 py-3 text-sm text-emerald-600 bg-emerald-50 border border-emerald-200 rounded-xl">
+                Профиль обновлён.
+              </div>
+            ) : null}
 
             <div className="flex flex-col gap-3 md:flex-row">
               <button
                 type="submit"
-                className="inline-flex justify-center px-5 py-3 text-sm font-semibold text-white bg-primary rounded-xl hover:bg-blue-700"
+                disabled={saveState.isSaving}
+                className={`inline-flex justify-center px-5 py-3 text-sm font-semibold text-white rounded-xl transition ${
+                  saveState.isSaving
+                    ? 'bg-blue-400 cursor-not-allowed'
+                    : 'bg-primary hover:bg-blue-700'
+                }`}
               >
-                Сохранить профиль
+                {saveState.isSaving ? 'Сохраняем…' : 'Сохранить профиль'}
               </button>
-              {isSaved ? (
-                <span className="px-5 py-3 text-sm font-semibold text-emerald-600 bg-emerald-50 rounded-xl">
+              {saveState.isSaved ? (
+                <span className="inline-flex items-center px-5 py-3 text-sm font-semibold text-emerald-600 bg-emerald-50 rounded-xl">
                   Изменения сохранены
                 </span>
               ) : null}
@@ -166,6 +259,21 @@ const ProfilePage = () => {
       </CabinetLayout>
     </>
   )
+}
+
+ProfilePage.propTypes = {
+  initialProfile: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    username: PropTypes.string,
+    phone: PropTypes.string,
+    about: PropTypes.string,
+    preferences: PropTypes.arrayOf(PropTypes.string),
+  }),
+}
+
+ProfilePage.defaultProps = {
+  initialProfile: normalizeUserProfile(),
 }
 
 export async function getServerSideProps(context) {
@@ -181,9 +289,35 @@ export async function getServerSideProps(context) {
     }
   }
 
+  const location = session?.user?.location ?? null
+  const rawTelegramId = session?.user?.telegramId
+  const numericTelegramId =
+    rawTelegramId === null || rawTelegramId === undefined ? null : Number(rawTelegramId)
+  const telegramId = Number.isFinite(numericTelegramId) ? numericTelegramId : null
+
+  let initialProfile = normalizeUserProfile()
+
+  if (location && telegramId !== null) {
+    try {
+      const db = await dbConnect(location)
+
+      if (db) {
+        const UsersModel = db.model('Users')
+        const profileDoc = await UsersModel.findOne({ telegramId }).lean()
+
+        if (profileDoc) {
+          initialProfile = normalizeUserProfile(profileDoc)
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load profile data', error)
+    }
+  }
+
   return {
     props: {
       session,
+      initialProfile,
     },
   }
 }

--- a/pages/cabinet/teams.js
+++ b/pages/cabinet/teams.js
@@ -1,67 +1,399 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
 import Head from 'next/head'
+import { useSession } from 'next-auth/react'
+
 import CabinetLayout from '@components/cabinet/CabinetLayout'
 import getSessionSafe from '@helpers/getSessionSafe'
+import formatRelativeTimeFromNow from '@helpers/formatRelativeTimeFromNow'
+import getGameStatusLabel from '@helpers/getGameStatusLabel'
+import { getNounUsers } from '@helpers/getNoun'
+import normalizeTeamForCabinet from '@helpers/normalizeTeamForCabinet'
+import dbConnect from '@utils/dbConnect'
 
-const initialTeams = [
-  {
-    id: 'team-1',
-    name: 'Северный свет',
-    captain: 'Анна Петрова',
-    participants: 6,
-    game: 'Ночная прогулка',
-    notes: 'Готовы стартовать в любое время после 20:00.',
-  },
-  {
-    id: 'team-2',
-    name: 'Городские исследователи',
-    captain: 'Максим Фёдоров',
-    participants: 5,
-    game: 'Весенний забег',
-    notes: 'Нужна дополнительная карта для новичков.',
-  },
-  {
-    id: 'team-3',
-    name: 'Точка сборки',
-    captain: 'Елена Лебедева',
-    participants: 7,
-    game: 'Квест для новичков',
-    notes: 'Участники просят добавить фотоинструкции.',
-  },
-]
+const serializeTeamForComparison = (team) => {
+  if (!team) {
+    return null
+  }
 
-const TeamsPage = () => {
+  return JSON.stringify({
+    name: team.name ?? '',
+    description: team.description ?? '',
+    open: Boolean(team.open),
+  })
+}
+
+const buildTeamUpdatePayload = (team) => {
+  const name = team.name ?? ''
+
+  return {
+    name,
+    name_lowered: name.toLowerCase(),
+    description: team.description ?? '',
+    open: Boolean(team.open),
+  }
+}
+
+const normalizePhoneLink = (phone) => {
+  if (!phone) {
+    return ''
+  }
+
+  return phone.replace(/[^+\d]/g, '')
+}
+
+const TeamsPage = ({ initialTeams, initialLocation, session: initialSession }) => {
+  const { data: session } = useSession()
+  const activeSession = session ?? initialSession ?? null
+  const location = activeSession?.user?.location ?? initialLocation ?? null
+  const userRole = activeSession?.user?.role ?? 'client'
+  const currentTelegramId = activeSession?.user?.telegramId ?? null
+  const currentTelegramIdString =
+    currentTelegramId === null || currentTelegramId === undefined
+      ? null
+      : String(currentTelegramId)
+
   const [teams, setTeams] = useState(initialTeams)
-  const [selectedTeamId, setSelectedTeamId] = useState(initialTeams[0].id)
+  const [persistedTeams, setPersistedTeams] = useState(initialTeams)
+  const [selectedTeamId, setSelectedTeamId] = useState(initialTeams[0]?.id ?? null)
+  const [feedback, setFeedback] = useState(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [memberActionId, setMemberActionId] = useState(null)
+
+  useEffect(() => {
+    setTeams(initialTeams)
+    setPersistedTeams(initialTeams)
+    setSelectedTeamId((prev) => {
+      if (prev && initialTeams.some((team) => team.id === prev)) {
+        return prev
+      }
+
+      return initialTeams[0]?.id ?? null
+    })
+  }, [initialTeams])
+
+  useEffect(() => {
+    setFeedback(null)
+    setMemberActionId(null)
+  }, [selectedTeamId])
 
   const selectedTeam = useMemo(
-    () => teams.find((team) => team.id === selectedTeamId),
+    () => teams.find((team) => team.id === selectedTeamId) ?? null,
     [teams, selectedTeamId]
   )
 
-  const updateSelectedTeam = (field, value) => {
-    setTeams((prevTeams) =>
-      prevTeams.map((team) =>
-        team.id === selectedTeamId
-          ? {
-              ...team,
-              [field]: value,
-            }
-          : team
-      )
-    )
-  }
+  const persistedSelectedTeam = useMemo(
+    () => persistedTeams.find((team) => team.id === selectedTeamId) ?? null,
+    [persistedTeams, selectedTeamId]
+  )
 
-  const removeSelectedTeam = () => {
-    setTeams((prevTeams) => prevTeams.filter((team) => team.id !== selectedTeamId))
-    setSelectedTeamId((prevId) => {
-      if (prevId === selectedTeamId) {
-        return teams.find((team) => team.id !== selectedTeamId)?.id ?? null
+  const isDirty = useMemo(() => {
+    if (!selectedTeam || !persistedSelectedTeam) {
+      return false
+    }
+
+    return (
+      serializeTeamForComparison(selectedTeam) !==
+      serializeTeamForComparison(persistedSelectedTeam)
+    )
+  }, [persistedSelectedTeam, selectedTeam])
+
+  const isAdmin = userRole === 'admin' || userRole === 'dev'
+  const isTeamCaptain = useMemo(() => {
+    if (!selectedTeam || !currentTelegramIdString) {
+      return false
+    }
+
+    return selectedTeam.members?.some(
+      (member) => member.isCaptain && member.telegramId === currentTelegramIdString
+    )
+  }, [currentTelegramIdString, selectedTeam])
+
+  const canManageSelectedTeam = isAdmin || isTeamCaptain
+
+  const updateSelectedTeam = useCallback(
+    (updater) => {
+      if (!selectedTeamId || !canManageSelectedTeam) {
+        return
       }
 
-      return prevId
+      setTeams((prevTeams) =>
+        prevTeams.map((team) => {
+          if (team.id !== selectedTeamId) {
+            return team
+          }
+
+          const patch = typeof updater === 'function' ? updater(team) : updater
+          return { ...team, ...patch }
+        })
+      )
+    },
+    [canManageSelectedTeam, selectedTeamId]
+  )
+
+  const handleTeamFieldChange = useCallback(
+    (field, value) => {
+      if (!canManageSelectedTeam) {
+        return
+      }
+
+      setFeedback(null)
+      updateSelectedTeam({ [field]: value })
+    },
+    [canManageSelectedTeam, updateSelectedTeam]
+  )
+
+  const handleResetTeam = useCallback(() => {
+    if (!selectedTeamId || !canManageSelectedTeam) {
+      return
+    }
+
+    setTeams((prevTeams) =>
+      prevTeams.map((team) => {
+        if (team.id !== selectedTeamId) {
+          return team
+        }
+
+        const original = persistedTeams.find((item) => item.id === selectedTeamId)
+        return original ? { ...original } : team
+      })
+    )
+    setFeedback(null)
+  }, [canManageSelectedTeam, persistedTeams, selectedTeamId])
+
+  const handleSaveTeam = useCallback(async () => {
+    if (!selectedTeam || !location || !canManageSelectedTeam) {
+      return
+    }
+
+    setIsSaving(true)
+    setFeedback(null)
+
+    try {
+      const response = await fetch(`/api/${location}/teams/${selectedTeam.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: buildTeamUpdatePayload(selectedTeam) }),
+      })
+
+      const json = await response.json()
+
+      if (!response.ok || json?.success === false) {
+        throw new Error(json?.error || 'Не удалось сохранить команду')
+      }
+
+      const updatedTeam = {
+        ...selectedTeam,
+        name: json.data?.name ?? selectedTeam.name,
+        description: json.data?.description ?? selectedTeam.description,
+        open: Boolean(json.data?.open ?? selectedTeam.open),
+        updatedAt: json.data?.updatedAt
+          ? new Date(json.data.updatedAt).toISOString()
+          : selectedTeam.updatedAt,
+      }
+
+      setTeams((prevTeams) =>
+        prevTeams.map((team) => (team.id === selectedTeamId ? updatedTeam : team))
+      )
+      setPersistedTeams((prevTeams) =>
+        prevTeams.map((team) => (team.id === selectedTeamId ? updatedTeam : team))
+      )
+      setFeedback({ type: 'success', message: 'Изменения сохранены' })
+    } catch (error) {
+      console.error('Failed to update team', error)
+      setFeedback({
+        type: 'error',
+        message: error?.message || 'Не удалось сохранить команду',
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }, [canManageSelectedTeam, location, selectedTeam, selectedTeamId])
+
+  const handleRemoveMember = useCallback(
+    async (memberId) => {
+      if (!selectedTeam || !canManageSelectedTeam || !location) {
+        return
+      }
+
+      const member = selectedTeam.members.find((item) => item.id === memberId)
+      if (!member) {
+        return
+      }
+
+      if (member.isCaptain) {
+        setFeedback({
+          type: 'error',
+          message: 'Нельзя удалить капитана команды. Назначьте нового капитана и повторите действие.',
+        })
+        return
+      }
+
+      setMemberActionId(memberId)
+      setFeedback(null)
+
+      try {
+        const response = await fetch(`/api/${location}/teamsusers/${memberId}`, {
+          method: 'DELETE',
+        })
+        const json = await response.json()
+
+        if (!response.ok || json?.success === false) {
+          throw new Error(json?.error || 'Не удалось удалить участника')
+        }
+
+        const updatedMembers = (selectedTeam.members ?? []).filter(
+          (item) => item.id !== memberId
+        )
+        const updatedTeam = {
+          ...selectedTeam,
+          members: updatedMembers,
+          membersCount: updatedMembers.length,
+          captain: updatedMembers.find((item) => item.isCaptain) ?? null,
+        }
+
+        setTeams((prevTeams) =>
+          prevTeams.map((team) => (team.id === selectedTeamId ? updatedTeam : team))
+        )
+        setPersistedTeams((prevTeams) =>
+          prevTeams.map((team) => (team.id === selectedTeamId ? updatedTeam : team))
+        )
+
+        setFeedback({
+          type: 'success',
+          message: `Участник «${member.name || 'Без имени'}» удалён из команды`,
+        })
+      } catch (error) {
+        console.error('Failed to remove team member', error)
+        setFeedback({
+          type: 'error',
+          message: error?.message || 'Не удалось удалить участника',
+        })
+      } finally {
+        setMemberActionId(null)
+      }
+    },
+    [canManageSelectedTeam, location, selectedTeam, selectedTeamId]
+  )
+
+  const handleSetCaptain = useCallback(
+    async (memberId) => {
+      if (!selectedTeam || !canManageSelectedTeam || !location) {
+        return
+      }
+
+      const member = selectedTeam.members.find((item) => item.id === memberId)
+      if (!member || member.isCaptain) {
+        return
+      }
+
+      const currentCaptain = selectedTeam.members.find((item) => item.isCaptain)
+
+      setMemberActionId(memberId)
+      setFeedback(null)
+
+      try {
+        const requests = [
+          fetch(`/api/${location}/teamsusers/${memberId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ data: { role: 'capitan' } }),
+          }),
+        ]
+
+        if (currentCaptain) {
+          requests.push(
+            fetch(`/api/${location}/teamsusers/${currentCaptain.id}`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ data: { role: 'participant' } }),
+            })
+          )
+        }
+
+        const responses = await Promise.all(requests)
+        const payloads = await Promise.all(responses.map((res) => res.json()))
+
+        responses.forEach((res, index) => {
+          if (!res.ok || payloads[index]?.success === false) {
+            throw new Error(payloads[index]?.error || 'Не удалось обновить роль участника')
+          }
+        })
+
+        const updatedMembers = (selectedTeam.members ?? []).map((item) => {
+          if (item.id === memberId) {
+            return { ...item, role: 'capitan', isCaptain: true }
+          }
+
+          if (item.id === currentCaptain?.id) {
+            return { ...item, role: 'participant', isCaptain: false }
+          }
+
+          return item
+        })
+
+        const updatedTeam = {
+          ...selectedTeam,
+          members: updatedMembers,
+          captain: updatedMembers.find((item) => item.isCaptain) ?? null,
+        }
+
+        setTeams((prevTeams) =>
+          prevTeams.map((team) => (team.id === selectedTeamId ? updatedTeam : team))
+        )
+        setPersistedTeams((prevTeams) =>
+          prevTeams.map((team) => (team.id === selectedTeamId ? updatedTeam : team))
+        )
+
+        setFeedback({
+          type: 'success',
+          message: `«${member.name || 'Участник'}» назначен капитаном команды`,
+        })
+      } catch (error) {
+        console.error('Failed to promote team member', error)
+        setFeedback({
+          type: 'error',
+          message: error?.message || 'Не удалось изменить роль участника',
+        })
+      } finally {
+        setMemberActionId(null)
+      }
+    },
+    [canManageSelectedTeam, location, selectedTeam, selectedTeamId]
+  )
+
+  const teamRestrictionMessage = useMemo(() => {
+    if (!selectedTeam || canManageSelectedTeam) {
+      return null
+    }
+
+    if (selectedTeam.captain && selectedTeam.captain.telegramId === currentTelegramIdString) {
+      return null
+    }
+
+    return 'Изменять данные может только администратор или капитан команды. Вы можете просматривать информацию.'
+  }, [canManageSelectedTeam, currentTelegramIdString, selectedTeam])
+
+  const teamsForList = useMemo(() => {
+    if (!Array.isArray(teams)) {
+      return []
+    }
+
+    return teams.map((team) => {
+      const updatedLabel = team.updatedAt
+        ? formatRelativeTimeFromNow(team.updatedAt)
+        : '—'
+
+      return {
+        id: team.id,
+        name: team.name || 'Без названия',
+        membersCount: getNounUsers(team.membersCount ?? 0),
+        gamesCount: team.gamesCount ?? 0,
+        updatedLabel,
+        open: Boolean(team.open),
+      }
     })
-  }
+  }, [teams])
 
   return (
     <>
@@ -70,122 +402,311 @@ const TeamsPage = () => {
       </Head>
       <CabinetLayout
         title="Мои команды"
-        description="Управляйте составом, отправляйте приглашения и отслеживайте прогресс участников."
+        description="Следите за составом, назначайте капитанов и контролируйте участие в играх."
         activePage="teams"
       >
         <section className="grid gap-6 md:grid-cols-5">
-          <div className="md:col-span-2">
-            <ul className="space-y-3">
-              {teams.map((team) => (
-                <li key={team.id}>
-                  <button
-                    type="button"
-                    onClick={() => setSelectedTeamId(team.id)}
-                    className={`w-full text-left p-4 border rounded-2xl transition hover:border-primary hover:bg-blue-50 ${
-                      selectedTeamId === team.id
-                        ? 'border-primary bg-blue-50 shadow-sm'
-                        : 'border-slate-200 bg-white'
-                    }`}
-                  >
-                    <p className="text-sm font-semibold text-primary">{team.name}</p>
-                    <p className="mt-1 text-xs text-slate-500">Капитан: {team.captain}</p>
-                    <p className="mt-1 text-xs text-slate-400">Игра: {team.game}</p>
-                  </button>
-                </li>
-              ))}
-            </ul>
+          <div className="md:col-span-2 space-y-4">
+            <div className="p-4 bg-white border border-slate-200 rounded-2xl shadow-sm">
+              <p className="text-sm font-semibold text-primary">Ваши команды</p>
+              <p className="mt-1 text-xs text-slate-500">
+                Выберите команду, чтобы просмотреть состав и изменить основные параметры.
+              </p>
+            </div>
+
+            {teamsForList.length > 0 ? (
+              <ul className="space-y-3">
+                {teamsForList.map((team) => (
+                  <li key={team.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedTeamId(team.id)}
+                      className={`w-full text-left p-4 border rounded-2xl transition hover:border-primary hover:bg-blue-50 ${
+                        selectedTeamId === team.id
+                          ? 'border-primary bg-blue-50 shadow-sm'
+                          : 'border-slate-200 bg-white'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-semibold text-primary">{team.name}</p>
+                        <span
+                          className={`text-xs font-medium px-2 py-1 rounded-full ${
+                            team.open
+                              ? 'bg-emerald-50 text-emerald-600 border border-emerald-200'
+                              : 'bg-slate-100 text-slate-600 border border-slate-200'
+                          }`}
+                        >
+                          {team.open ? 'Открыта' : 'Закрыта'}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs text-slate-500">{team.membersCount}</p>
+                      <p className="mt-1 text-xs text-slate-400">
+                        {team.gamesCount > 0
+                          ? `Игр: ${team.gamesCount} · Обновлено ${team.updatedLabel}`
+                          : `Обновлено ${team.updatedLabel}`}
+                      </p>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="p-6 text-sm text-center text-slate-500 bg-white border border-slate-200 rounded-2xl shadow-sm">
+                У вас пока нет команд. Создайте команду в телеграм-боте, чтобы она появилась в списке.
+              </div>
+            )}
           </div>
 
           <div className="md:col-span-3">
             {selectedTeam ? (
-              <div className="p-6 space-y-5 bg-white border border-slate-200 rounded-2xl shadow-sm">
-                <div>
-                  <label htmlFor="team-name" className="text-sm font-semibold text-primary">
-                    Название команды
-                  </label>
-                  <input
-                    id="team-name"
-                    type="text"
-                    value={selectedTeam.name}
-                    onChange={(event) => updateSelectedTeam('name', event.target.value)}
-                    className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                  />
-                </div>
-
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div>
-                    <label htmlFor="team-captain" className="text-sm font-semibold text-primary">
-                      Капитан
-                    </label>
-                    <input
-                      id="team-captain"
-                      type="text"
-                      value={selectedTeam.captain}
-                      onChange={(event) => updateSelectedTeam('captain', event.target.value)}
-                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                    />
-                  </div>
-
-                  <div>
-                    <label htmlFor="team-members" className="text-sm font-semibold text-primary">
-                      Участников
-                    </label>
-                    <input
-                      id="team-members"
-                      type="number"
-                      min="1"
-                      value={selectedTeam.participants}
-                      onChange={(event) => updateSelectedTeam('participants', Number(event.target.value))}
-                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                    />
+              <div className="space-y-6">
+                <div className="p-5 bg-white border border-slate-200 rounded-2xl shadow-sm">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span
+                      className={`px-2.5 py-1 text-xs font-semibold rounded-full border ${
+                        selectedTeam.open
+                          ? 'text-emerald-600 bg-emerald-50 border-emerald-200'
+                          : 'text-slate-600 bg-slate-100 border-slate-200'
+                      }`}
+                    >
+                      {selectedTeam.open ? 'Открыта для заявок' : 'Закрытый состав'}
+                    </span>
+                    <span className="text-xs text-slate-500">
+                      Участников: {selectedTeam.membersCount ?? 0}
+                    </span>
+                    <span className="text-xs text-slate-500">
+                      Участвует в играх: {selectedTeam.gamesCount ?? 0}
+                    </span>
+                    {selectedTeam.updatedAt && (
+                      <span className="text-xs text-slate-500">
+                        Обновлено {formatRelativeTimeFromNow(selectedTeam.updatedAt)}
+                      </span>
+                    )}
                   </div>
                 </div>
 
-                <div>
-                  <label htmlFor="team-game" className="text-sm font-semibold text-primary">
-                    Игра
-                  </label>
-                  <input
-                    id="team-game"
-                    type="text"
-                    value={selectedTeam.game}
-                    onChange={(event) => updateSelectedTeam('game', event.target.value)}
-                    className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                  />
-                </div>
+                {!location && (
+                  <div className="p-4 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-2xl">
+                    Не удалось определить площадку пользователя. Сохранение изменений недоступно.
+                  </div>
+                )}
 
-                <div>
-                  <label htmlFor="team-notes" className="text-sm font-semibold text-primary">
-                    Заметки
-                  </label>
-                  <textarea
-                    id="team-notes"
-                    value={selectedTeam.notes}
-                    onChange={(event) => updateSelectedTeam('notes', event.target.value)}
-                    rows={6}
-                    className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
-                  />
-                </div>
+                {feedback && (
+                  <div
+                    className={`p-4 text-sm border rounded-2xl ${
+                      feedback.type === 'success'
+                        ? 'bg-emerald-50 border-emerald-200 text-emerald-700'
+                        : 'bg-rose-50 border-rose-200 text-rose-700'
+                    }`}
+                  >
+                    {feedback.message}
+                  </div>
+                )}
 
-                <div className="flex flex-col gap-3 md:flex-row">
-                  <button
-                    type="button"
-                    className="inline-flex justify-center px-5 py-3 text-sm font-semibold text-white bg-primary rounded-xl hover:bg-blue-700"
-                  >
-                    Сохранить изменения
-                  </button>
-                  <button
-                    type="button"
-                    onClick={removeSelectedTeam}
-                    className="inline-flex justify-center px-5 py-3 text-sm font-semibold text-rose-600 border border-rose-200 rounded-xl hover:bg-rose-50"
-                  >
-                    Удалить команду
-                  </button>
-                </div>
+                {teamRestrictionMessage && (
+                  <div className="p-4 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-2xl">
+                    {teamRestrictionMessage}
+                  </div>
+                )}
+
+                <fieldset disabled={!canManageSelectedTeam} className="space-y-6 border-0 p-0 m-0">
+                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <div>
+                        <label htmlFor="team-name" className="text-sm font-semibold text-primary">
+                          Название команды
+                        </label>
+                        <input
+                          id="team-name"
+                          type="text"
+                          value={selectedTeam.name}
+                          onChange={(event) => handleTeamFieldChange('name', event.target.value)}
+                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-sm font-semibold text-primary" htmlFor="team-open">
+                          Доступность команды
+                        </label>
+                        <div className="flex items-center gap-3 mt-3">
+                          <input
+                            id="team-open"
+                            type="checkbox"
+                            checked={Boolean(selectedTeam.open)}
+                            onChange={(event) => handleTeamFieldChange('open', event.target.checked)}
+                            className="w-4 h-4 text-primary border-slate-300 rounded"
+                          />
+                          <span className="text-sm text-slate-600">
+                            Разрешить новым участникам подавать заявки
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div>
+                      <label htmlFor="team-description" className="text-sm font-semibold text-primary">
+                        Описание
+                      </label>
+                      <textarea
+                        id="team-description"
+                        value={selectedTeam.description}
+                        onChange={(event) => handleTeamFieldChange('description', event.target.value)}
+                        rows={5}
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                  </section>
+
+                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                    <div className="flex items-center justify-between">
+                      <h2 className="text-lg font-semibold text-primary">Состав команды</h2>
+                      {selectedTeam.captain && (
+                        <span className="text-xs text-slate-500">
+                          Капитан: {selectedTeam.captain.name || 'не указан'}
+                        </span>
+                      )}
+                    </div>
+
+                    {selectedTeam.members?.length > 0 ? (
+                      <div className="space-y-3">
+                        {selectedTeam.members.map((member) => {
+                          const phoneLink = normalizePhoneLink(member.phone)
+                          const isProcessing = memberActionId === member.id
+
+                          return (
+                            <div
+                              key={member.id}
+                              className="p-4 border border-slate-200 rounded-2xl bg-white shadow-sm"
+                            >
+                              <div className="flex flex-wrap items-start justify-between gap-3">
+                                <div>
+                                  <p className="text-sm font-semibold text-primary">
+                                    {member.name || 'Без имени'}
+                                    {member.isCaptain ? ' · Капитан' : ''}
+                                  </p>
+                                  {member.username && (
+                                    <p className="mt-1 text-xs text-slate-500">@{member.username}</p>
+                                  )}
+                                  {member.userRole && (
+                                    <p className="mt-1 text-xs text-slate-400">
+                                      Роль в системе: {member.userRole}
+                                    </p>
+                                  )}
+                                </div>
+                                <div className="text-right">
+                                  {member.phone && (
+                                    <a
+                                      href={phoneLink ? `tel:${phoneLink}` : undefined}
+                                      className="block text-xs text-primary hover:underline"
+                                    >
+                                      {member.phone}
+                                    </a>
+                                  )}
+                                </div>
+                              </div>
+
+                              {canManageSelectedTeam && (
+                                <div className="flex flex-col gap-2 mt-3 md:flex-row">
+                                  {!member.isCaptain && (
+                                    <button
+                                      type="button"
+                                      onClick={() => handleSetCaptain(member.id)}
+                                      disabled={isProcessing}
+                                      className={`inline-flex justify-center px-4 py-2 text-xs font-semibold rounded-xl border transition ${
+                                        isProcessing
+                                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                                          : 'border-primary text-primary hover:bg-blue-50'
+                                      }`}
+                                    >
+                                      Назначить капитаном
+                                    </button>
+                                  )}
+                                  {!member.isCaptain && (
+                                    <button
+                                      type="button"
+                                      onClick={() => handleRemoveMember(member.id)}
+                                      disabled={isProcessing}
+                                      className={`inline-flex justify-center px-4 py-2 text-xs font-semibold rounded-xl border transition ${
+                                        isProcessing
+                                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                                          : 'border-rose-200 text-rose-600 hover:bg-rose-50'
+                                      }`}
+                                    >
+                                      Удалить из команды
+                                    </button>
+                                  )}
+                                </div>
+                              )}
+                            </div>
+                          )
+                        })}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-slate-500">
+                        Пока нет участников. Пригласите игроков через телеграм-бота, чтобы они появились здесь.
+                      </p>
+                    )}
+                  </section>
+
+                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-4">
+                    <h2 className="text-lg font-semibold text-primary">Игры команды</h2>
+                    {selectedTeam.games?.length > 0 ? (
+                      <ul className="space-y-3">
+                        {selectedTeam.games.map((game) => (
+                          <li key={game.id} className="p-4 border border-slate-200 rounded-2xl bg-slate-50">
+                            <div className="flex flex-wrap items-center justify-between gap-3">
+                              <p className="text-sm font-semibold text-primary">{game.name || 'Без названия'}</p>
+                              <span className="text-xs text-slate-500">
+                                {game.dateStart
+                                  ? new Date(game.dateStart).toLocaleString('ru-RU', {
+                                      dateStyle: 'short',
+                                      timeStyle: 'short',
+                                    })
+                                  : 'Дата не указана'}
+                              </span>
+                            </div>
+                            <p className="mt-1 text-xs text-slate-500">
+                              {getGameStatusLabel(game.status)}
+                              {game.hidden ? ' · Скрыта' : ''}
+                            </p>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-sm text-slate-500">Команда пока не зарегистрирована ни в одной игре.</p>
+                    )}
+                  </section>
+
+                  <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                    <button
+                      type="button"
+                      onClick={handleSaveTeam}
+                      disabled={!canManageSelectedTeam || !location || !isDirty || isSaving}
+                      className={`inline-flex justify-center px-5 py-3 text-sm font-semibold text-white rounded-xl transition ${
+                        !canManageSelectedTeam || !location || !isDirty || isSaving
+                          ? 'bg-slate-400 cursor-not-allowed'
+                          : 'bg-primary hover:bg-blue-700'
+                      }`}
+                    >
+                      {isSaving ? 'Сохранение…' : 'Сохранить изменения'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleResetTeam}
+                      disabled={!canManageSelectedTeam || !isDirty}
+                      className={`inline-flex justify-center px-5 py-3 text-sm font-semibold rounded-xl border transition ${
+                        !canManageSelectedTeam || !isDirty
+                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                          : 'border-primary text-primary hover:bg-blue-50'
+                      }`}
+                    >
+                      Отменить изменения
+                    </button>
+                  </div>
+                </fieldset>
               </div>
             ) : (
-              <div className="flex items-center justify-center h-full p-6 bg-white border border-dashed rounded-2xl border-slate-200">
-                <p className="text-sm text-slate-500">Выберите команду, чтобы просмотреть состав и контактные данные.</p>
+              <div className="flex items-center justify-center h-full p-6 bg-white border border-dashed border-slate-200 rounded-2xl">
+                <p className="text-sm text-slate-500">Выберите команду из списка слева, чтобы просмотреть детали.</p>
               </div>
             )}
           </div>
@@ -193,6 +714,51 @@ const TeamsPage = () => {
       </CabinetLayout>
     </>
   )
+}
+
+const teamMemberShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  telegramId: PropTypes.string,
+  name: PropTypes.string,
+  username: PropTypes.string,
+  phone: PropTypes.string,
+  role: PropTypes.string,
+  isCaptain: PropTypes.bool,
+  userRole: PropTypes.string,
+})
+
+const teamGameShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  status: PropTypes.string,
+  dateStart: PropTypes.string,
+  hidden: PropTypes.bool,
+})
+
+TeamsPage.propTypes = {
+  initialTeams: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string,
+      description: PropTypes.string,
+      open: PropTypes.bool,
+      members: PropTypes.arrayOf(teamMemberShape),
+      membersCount: PropTypes.number,
+      captain: teamMemberShape,
+      games: PropTypes.arrayOf(teamGameShape),
+      gamesCount: PropTypes.number,
+      createdAt: PropTypes.string,
+      updatedAt: PropTypes.string,
+    })
+  ),
+  initialLocation: PropTypes.string,
+  session: PropTypes.object,
+}
+
+TeamsPage.defaultProps = {
+  initialTeams: [],
+  initialLocation: null,
+  session: null,
 }
 
 export async function getServerSideProps(context) {
@@ -208,9 +774,170 @@ export async function getServerSideProps(context) {
     }
   }
 
+  const location = session?.user?.location ?? null
+  const userRole = session?.user?.role ?? 'client'
+  const rawTelegramId = session?.user?.telegramId
+  const numericTelegramId =
+    rawTelegramId === null || rawTelegramId === undefined
+      ? null
+      : Number(rawTelegramId)
+
+  let initialTeams = []
+
+  if (location) {
+    try {
+      const db = await dbConnect(location)
+
+      if (db) {
+        const TeamsModel = db.model('Teams')
+        const TeamsUsersModel = db.model('TeamsUsers')
+        const UsersModel = db.model('Users')
+        const GamesTeamsModel = db.model('GamesTeams')
+        const GamesModel = db.model('Games')
+
+        let teamsDocs = []
+        const isPrivileged = userRole === 'admin' || userRole === 'dev'
+
+        if (isPrivileged) {
+          teamsDocs = await TeamsModel.find({})
+            .sort({ updatedAt: -1 })
+            .lean()
+        } else if (Number.isFinite(numericTelegramId)) {
+          const memberships = await TeamsUsersModel.find({ userTelegramId: numericTelegramId })
+            .select({ teamId: 1 })
+            .lean()
+
+          const teamIds = [
+            ...new Set(
+              memberships
+                .map((membership) =>
+                  membership?.teamId ? membership.teamId.toString() : null
+                )
+                .filter(Boolean)
+            ),
+          ]
+
+          if (teamIds.length > 0) {
+            teamsDocs = await TeamsModel.find({ _id: { $in: teamIds } })
+              .sort({ updatedAt: -1 })
+              .lean()
+          }
+        }
+
+        if (teamsDocs.length > 0) {
+          const teamIds = teamsDocs
+            .map((team) => (team?._id ? team._id.toString() : null))
+            .filter(Boolean)
+
+          const teamMembersDocs = teamIds.length
+            ? await TeamsUsersModel.find({ teamId: { $in: teamIds } }).lean()
+            : []
+
+          const memberTelegramIds = [
+            ...new Set(
+              teamMembersDocs
+                .map((doc) =>
+                  Number.isFinite(doc?.userTelegramId) ? doc.userTelegramId : null
+                )
+                .filter((id) => id !== null)
+            ),
+          ]
+
+          const usersDocs = memberTelegramIds.length
+            ? await UsersModel.find({ telegramId: { $in: memberTelegramIds } })
+                .select({ telegramId: 1, name: 1, username: 1, phone: 1, role: 1 })
+                .lean()
+            : []
+
+          const usersMap = usersDocs.reduce((acc, user) => {
+            if (user?.telegramId !== undefined && user?.telegramId !== null) {
+              acc[user.telegramId] = user
+            }
+            return acc
+          }, {})
+
+          const membersByTeam = teamMembersDocs.reduce((acc, membership) => {
+            const teamId = membership?.teamId ? membership.teamId.toString() : null
+            if (!teamId) {
+              return acc
+            }
+
+            if (!acc[teamId]) {
+              acc[teamId] = []
+            }
+
+            acc[teamId].push({
+              membershipId: membership?._id,
+              userTelegramId: membership?.userTelegramId ?? null,
+              role: membership?.role,
+              user: usersMap[membership?.userTelegramId] ?? null,
+            })
+
+            return acc
+          }, {})
+
+          const gamesTeamsDocs = teamIds.length
+            ? await GamesTeamsModel.find({ teamId: { $in: teamIds } })
+                .select({ teamId: 1, gameId: 1 })
+                .lean()
+            : []
+
+          const gameIds = [
+            ...new Set(
+              gamesTeamsDocs
+                .map((doc) => (doc?.gameId ? doc.gameId.toString() : null))
+                .filter(Boolean)
+            ),
+          ]
+
+          const gamesDocs = gameIds.length
+            ? await GamesModel.find({ _id: { $in: gameIds } })
+                .select({ _id: 1, name: 1, status: 1, dateStart: 1, hidden: 1 })
+                .lean()
+            : []
+
+          const gamesMap = gamesDocs.reduce((acc, game) => {
+            if (game?._id) {
+              acc[game._id.toString()] = game
+            }
+            return acc
+          }, {})
+
+          const gamesByTeam = gamesTeamsDocs.reduce((acc, doc) => {
+            const teamId = doc?.teamId ? doc.teamId.toString() : null
+            const game = doc?.gameId ? gamesMap[doc.gameId.toString()] : null
+
+            if (!teamId || !game) {
+              return acc
+            }
+
+            if (!acc[teamId]) {
+              acc[teamId] = []
+            }
+
+            acc[teamId].push(game)
+            return acc
+          }, {})
+
+          initialTeams = teamsDocs.map((team) =>
+            normalizeTeamForCabinet({
+              team,
+              members: membersByTeam[team._id.toString()] ?? [],
+              games: gamesByTeam[team._id.toString()] ?? [],
+            })
+          )
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load teams for cabinet', error)
+    }
+  }
+
   return {
     props: {
       session,
+      initialTeams,
+      initialLocation: location,
     },
   }
 }

--- a/schemas/siteSettingsSchema.js
+++ b/schemas/siteSettingsSchema.js
@@ -1,4 +1,6 @@
 const siteSettingsSchema = {
+  supportPhone: { type: String, default: null },
+  announcement: { type: String, default: null },
   chatUrl: { type: String, default: null },
 }
 

--- a/schemas/usersSchema.js
+++ b/schemas/usersSchema.js
@@ -34,6 +34,15 @@ const usersSchema = {
     type: Number,
     default: null,
   },
+  about: {
+    type: String,
+    default: '',
+    trim: true,
+  },
+  preferences: {
+    type: [String],
+    default: [],
+  },
   location: {
     type: {
       date: Date,


### PR DESCRIPTION
## Summary
- подключил страницу настроек к базе, добавил телефон поддержки и ссылку на чат, убрал лишние поля
- переработал профиль пользователя: переименовал страницу, загрузка/сохранение данных в БД и обновлённый UI
- обновил интерфейс кабинета: заменил шапку сайдбара, исправил быстрые действия и убрал блок запросов в админке

## Testing
- npm run build *(ошибка: Module not found: Can't resolve 'jotai')*

------
https://chatgpt.com/codex/tasks/task_e_68f6790f53288329887a6e19636cc68e