### PR TITLE
feat: добавить переключение темы в кабинете

### DIFF
--- a/components/cabinet/CabinetLayout.js
+++ b/components/cabinet/CabinetLayout.js
@@ -13,6 +13,8 @@ import {
   faUsers,
   faGaugeHigh,
   faSliders,
+  faMoon,
+  faSun,
 } from '@fortawesome/free-solid-svg-icons'
 import { LOCATIONS } from '@server/serverConstants'
 import isUserAdmin from '@helpers/isUserAdmin'
@@ -65,12 +67,15 @@ const CabinetLayout = ({ children, title, description, activePage }) => {
   const router = useRouter()
   const { data: session } = useSession()
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(false)
+  const [theme, setTheme] = useState('light')
+  const [isThemeInitialized, setIsThemeInitialized] = useState(false)
 
   const role = session?.user?.role ?? null
   const userName = session?.user?.name || session?.user?.username || 'Пользователь'
   const userAvatar = session?.user?.photoUrl ?? null
   const locationKey = session?.user?.location ?? null
   const locationName = normalizeLocationName(locationKey)
+  const isDarkTheme = theme === 'dark'
 
   const menuItems = useMemo(() => {
     if (isUserAdmin({ role })) {
@@ -101,116 +106,152 @@ const CabinetLayout = ({ children, title, description, activePage }) => {
     }
   }, [closeSidebarOnMobile, router])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const storedTheme = window.localStorage.getItem('cabinet-theme')
+
+    if (storedTheme === 'dark' || storedTheme === 'light') {
+      setTheme(storedTheme)
+    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark')
+    }
+
+    setIsThemeInitialized(true)
+  }, [])
+
+  useEffect(() => {
+    if (!isThemeInitialized || typeof window === 'undefined') {
+      return
+    }
+
+    window.localStorage.setItem('cabinet-theme', theme)
+    if (typeof document !== 'undefined') {
+      document.documentElement.style.colorScheme = isDarkTheme ? 'dark' : 'light'
+    }
+  }, [isDarkTheme, isThemeInitialized, theme])
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))
+  }, [])
+
   const handleSignOut = async () => {
     await signOut({ redirect: true, callbackUrl: '/' })
   }
 
   return (
-    <div className="flex min-h-screen bg-slate-100">
-      <div
-        className={`fixed inset-y-0 left-0 z-40 flex flex-col bg-white border-r border-slate-200 transition-all duration-200 md:static md:translate-x-0 md:w-64 ${
-          isSidebarExpanded ? 'w-64 translate-x-0 shadow-xl' : 'w-16 -translate-x-full md:translate-x-0'
-        }`}
-      >
-        <div className="flex items-center justify-center h-16 border-b border-slate-200">
-          <span className="text-lg font-semibold text-primary">ActQuest</span>
-        </div>
-        <nav className="flex-1 py-4 space-y-1 overflow-y-auto">
-          {menuItems.map((item) => {
-            const isActive =
-              activePage === item.id || router.pathname === item.href
-
-            return (
-              <Link key={item.id} href={item.href} legacyBehavior>
-                <a
-                  className={`flex items-center gap-4 px-4 py-3 text-sm font-medium transition-colors duration-150 ${
-                    isActive
-                      ? 'text-primary bg-blue-50 border-r-4 border-primary'
-                      : 'text-slate-600 hover:text-primary hover:bg-blue-50'
-                  } ${isSidebarExpanded ? 'justify-start' : 'justify-center md:justify-start'}`}
-                  onClick={closeSidebarOnMobile}
-                >
-                  <FontAwesomeIcon icon={item.icon} className="w-5 h-5" />
-                  <span
-                    className={`${isSidebarExpanded ? 'opacity-100' : 'opacity-0 md:opacity-100'} transition-opacity duration-150`}
-                  >
-                    {item.label}
-                  </span>
-                </a>
-              </Link>
-            )
-          })}
-        </nav>
-        <div className="px-4 py-4 border-t border-slate-200">
-          <button
-            type="button"
-            onClick={handleSignOut}
-            className="flex items-center w-full gap-3 px-3 py-2 text-sm font-medium text-slate-500 transition-colors duration-150 bg-slate-100 rounded-xl hover:text-primary hover:bg-blue-100"
-          >
-            <FontAwesomeIcon icon={faRightFromBracket} className="w-4 h-4" />
-            <span className={`${isSidebarExpanded ? 'opacity-100' : 'opacity-0 md:opacity-100'} transition-opacity duration-150`}>
-              Выйти
-            </span>
-          </button>
-        </div>
-      </div>
-
-      {isSidebarExpanded && (
+    <div className={isDarkTheme ? 'dark' : ''}>
+      <div className="flex min-h-screen bg-slate-100 dark:bg-slate-950">
         <div
-          className="fixed inset-0 z-30 bg-slate-900/40 md:hidden"
-          aria-hidden="true"
-          onClick={() => setIsSidebarExpanded(false)}
-        />
-      )}
+          className={`fixed inset-y-0 left-0 z-40 flex flex-col bg-white border-r border-slate-200 dark:bg-slate-900 dark:border-slate-800 transition-all duration-200 md:static md:translate-x-0 md:w-64 ${
+            isSidebarExpanded ? 'w-64 translate-x-0 shadow-xl' : 'w-16 -translate-x-full md:translate-x-0'
+          }`}
+        >
+          <div className="flex items-center justify-center h-16 border-b border-slate-200 dark:border-slate-800">
+            <span className="text-lg font-semibold text-primary dark:text-slate-100">ActQuest</span>
+          </div>
+          <nav className="flex-1 py-4 space-y-1 overflow-y-auto">
+            {menuItems.map((item) => {
+              const isActive = activePage === item.id || router.pathname === item.href
 
-      <div className="flex flex-col flex-1 min-h-screen">
-        <header className="sticky top-0 z-20 bg-white border-b border-slate-200">
-          <div className="flex items-center justify-between px-4 py-4 md:px-8">
-            <div className="flex items-center gap-4">
-              <button
-                type="button"
-                className="flex items-center justify-center w-10 h-10 text-slate-600 transition-colors duration-150 bg-slate-100 rounded-xl md:hidden hover:text-primary hover:bg-blue-100"
-                onClick={() => setIsSidebarExpanded((prev) => !prev)}
-                aria-label="Открыть меню"
-              >
-                <FontAwesomeIcon icon={faBars} className="w-4 h-4" />
-              </button>
-              <div>
-                <h1 className="text-xl font-semibold text-primary md:text-2xl">ActQuest</h1>
-                <p className="text-sm text-slate-500">{locationName}</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="hidden text-right md:block">
-                <p className="text-sm font-semibold text-primary">{userName}</p>
-                <p className="text-xs text-slate-500">{isUserAdmin({ role }) ? 'Администратор' : 'Участник'}</p>
-              </div>
-              {userAvatar ? (
-                <img
-                  src={userAvatar}
-                  alt={userName}
-                  className="object-cover w-10 h-10 rounded-full shadow-sm"
-                />
-              ) : (
-                <div className="flex items-center justify-center w-10 h-10 text-sm font-semibold text-white bg-primary rounded-full shadow-sm">
-                  {getInitials(userName, session?.user?.username)}
+              return (
+                <Link key={item.id} href={item.href} legacyBehavior>
+                  <a
+                    className={`flex items-center gap-4 px-4 py-3 text-sm font-medium transition-colors duration-150 ${
+                      isActive
+                        ? 'text-primary dark:text-blue-200 bg-blue-50 dark:bg-blue-500/10 border-r-4 border-primary dark:border-blue-400'
+                        : 'text-slate-600 dark:text-slate-300 hover:text-primary dark:hover:text-blue-200 hover:bg-blue-50 dark:hover:bg-blue-500/10'
+                    } ${isSidebarExpanded ? 'justify-start' : 'justify-center md:justify-start'}`}
+                    onClick={closeSidebarOnMobile}
+                  >
+                    <FontAwesomeIcon icon={item.icon} className="w-5 h-5" />
+                    <span
+                      className={`${isSidebarExpanded ? 'opacity-100' : 'opacity-0 md:opacity-100'} transition-opacity duration-150`}
+                    >
+                      {item.label}
+                    </span>
+                  </a>
+                </Link>
+              )
+            })}
+          </nav>
+          <div className="px-4 py-4 border-t border-slate-200 dark:border-slate-800">
+            <button
+              type="button"
+              onClick={handleSignOut}
+              className="flex items-center w-full gap-3 px-3 py-2 text-sm font-medium text-slate-500 transition-colors duration-150 bg-slate-100 rounded-xl hover:text-primary hover:bg-blue-100 dark:text-slate-300 dark:bg-slate-800 dark:hover:text-blue-200 dark:hover:bg-blue-500/20"
+            >
+              <FontAwesomeIcon icon={faRightFromBracket} className="w-4 h-4" />
+              <span className={`${isSidebarExpanded ? 'opacity-100' : 'opacity-0 md:opacity-100'} transition-opacity duration-150`}>
+                Выйти
+              </span>
+            </button>
+          </div>
+        </div>
+
+        {isSidebarExpanded && (
+          <div
+            className="fixed inset-0 z-30 bg-slate-900/40 md:hidden"
+            aria-hidden="true"
+            onClick={() => setIsSidebarExpanded(false)}
+          />
+        )}
+
+        <div className="flex flex-col flex-1 min-h-screen">
+          <header className="sticky top-0 z-20 bg-white border-b border-slate-200 dark:bg-slate-900 dark:border-slate-800">
+            <div className="flex items-center justify-between px-4 py-4 md:px-8">
+              <div className="flex items-center gap-4">
+                <button
+                  type="button"
+                  className="flex items-center justify-center w-10 h-10 text-slate-600 transition-colors duration-150 bg-slate-100 rounded-xl md:hidden hover:text-primary hover:bg-blue-100 dark:text-slate-300 dark:bg-slate-800 dark:hover:text-blue-200 dark:hover:bg-blue-500/20"
+                  onClick={() => setIsSidebarExpanded((prev) => !prev)}
+                  aria-label="Открыть меню"
+                >
+                  <FontAwesomeIcon icon={faBars} className="w-4 h-4" />
+                </button>
+                <div>
+                  <h1 className="text-xl font-semibold text-primary md:text-2xl dark:text-slate-100">ActQuest</h1>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">{locationName}</p>
                 </div>
-              )}
+              </div>
+              <div className="flex items-center gap-3 md:gap-4">
+                <button
+                  type="button"
+                  onClick={toggleTheme}
+                  className="flex items-center justify-center w-10 h-10 text-slate-600 transition-colors duration-150 bg-slate-100 rounded-xl hover:text-primary hover:bg-blue-100 dark:text-slate-300 dark:bg-slate-800 dark:hover:text-blue-200 dark:hover:bg-blue-500/20"
+                  aria-label={isDarkTheme ? 'Включить светлую тему' : 'Включить тёмную тему'}
+                >
+                  <FontAwesomeIcon icon={isDarkTheme ? faSun : faMoon} className="w-4 h-4" />
+                </button>
+                <div className="hidden text-right md:block">
+                  <p className="text-sm font-semibold text-primary dark:text-slate-100">{userName}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">{isUserAdmin({ role }) ? 'Администратор' : 'Участник'}</p>
+                </div>
+                {userAvatar ? (
+                  <img src={userAvatar} alt={userName} className="object-cover w-10 h-10 rounded-full shadow-sm" />
+                ) : (
+                  <div className="flex items-center justify-center w-10 h-10 text-sm font-semibold text-white bg-primary rounded-full shadow-sm dark:bg-blue-500">
+                    {getInitials(userName, session?.user?.username)}
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
-        </header>
+          </header>
 
-        <main className="flex-1 px-4 py-6 md:px-8">
-          <div className="max-w-5xl mx-auto">
-            <div className="mb-6">
-              <h2 className="text-2xl font-semibold text-primary">{title}</h2>
-              {description ? (
-                <p className="mt-1 text-sm text-slate-500">{description}</p>
-              ) : null}
+          <main className="flex-1 px-4 py-6 md:px-8">
+            <div className="max-w-5xl mx-auto">
+              <div className="mb-6">
+                <h2 className="text-2xl font-semibold text-primary dark:text-slate-100">{title}</h2>
+                {description ? (
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
+                ) : null}
+              </div>
+              <div className="space-y-6">{children}</div>
             </div>
-            <div className="space-y-6">{children}</div>
-          </div>
-        </main>
+          </main>
+        </div>
       </div>
     </div>
   )

--- a/pages/cabinet/index.js
+++ b/pages/cabinet/index.js
@@ -174,51 +174,55 @@ const CabinetDashboard = ({
           {normalizedStats.map((stat) => (
             <article
               key={stat.id}
-              className="p-5 transition-shadow bg-white border border-slate-200 rounded-2xl shadow-sm hover:shadow-md"
+              className="p-5 transition-shadow bg-white border border-slate-200 rounded-2xl shadow-sm hover:shadow-md dark:bg-slate-900/80 dark:border-slate-700 dark:hover:shadow-lg"
             >
-              <p className="text-sm font-medium text-slate-500">{stat.title}</p>
-              <p className="mt-3 text-3xl font-semibold text-primary">{stat.value}</p>
-              <p className="mt-2 text-xs font-medium text-slate-500">{stat.description}</p>
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">{stat.title}</p>
+              <p className="mt-3 text-3xl font-semibold text-primary dark:text-slate-100">{stat.value}</p>
+              <p className="mt-2 text-xs font-medium text-slate-500 dark:text-slate-400">{stat.description}</p>
             </article>
           ))}
         </section>
 
         <section className="grid gap-6 md:grid-cols-5">
-          <div className="md:col-span-3 p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
-            <h3 className="text-lg font-semibold text-primary">Быстрые действия</h3>
-            <p className="mt-1 text-sm text-slate-500">
+          <div className="md:col-span-3 p-6 bg-white border border-slate-200 rounded-2xl shadow-sm dark:bg-slate-900/80 dark:border-slate-700">
+            <h3 className="text-lg font-semibold text-primary dark:text-slate-100">Быстрые действия</h3>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               Сосредоточьтесь на задачах — переходите к нужным разделам без лишних шагов.
             </p>
             <div className="mt-4 space-y-4">
               {quickActions.map((action) => (
-                <a key={action.id} href={action.href} className="block p-4 transition bg-slate-50 rounded-xl hover:bg-blue-50">
-                  <p className="text-sm font-semibold text-primary">{action.title}</p>
-                  <p className="mt-1 text-xs text-slate-500">{action.description}</p>
+                <a
+                  key={action.id}
+                  href={action.href}
+                  className="block p-4 transition bg-slate-50 rounded-xl hover:bg-blue-50 dark:bg-slate-800 dark:hover:bg-blue-500/10"
+                >
+                  <p className="text-sm font-semibold text-primary dark:text-slate-100">{action.title}</p>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{action.description}</p>
                 </a>
               ))}
             </div>
           </div>
 
-          <div className="md:col-span-2 p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
-            <h3 className="text-lg font-semibold text-primary">Лента активности</h3>
-            <p className="mt-1 text-sm text-slate-500">
+          <div className="md:col-span-2 p-6 bg-white border border-slate-200 rounded-2xl shadow-sm dark:bg-slate-900/80 dark:border-slate-700">
+            <h3 className="text-lg font-semibold text-primary dark:text-slate-100">Лента активности</h3>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               Последние изменения, которые произошли в вашем кабинете.
             </p>
             <ul className="mt-4 space-y-4">
               {activityItems.length > 0 ? (
                 activityItems.map((item) => (
-                  <li key={item.id} className="p-4 bg-slate-50 rounded-xl">
-                    <p className="text-sm font-semibold text-primary">{item.title}</p>
-                    <p className="mt-2 text-xs text-slate-500">{item.details}</p>
-                    <div className="flex items-center justify-between mt-3 text-xs text-slate-500">
+                  <li key={item.id} className="p-4 bg-slate-50 rounded-xl dark:bg-slate-800">
+                    <p className="text-sm font-semibold text-primary dark:text-slate-100">{item.title}</p>
+                    <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">{item.details}</p>
+                    <div className="flex items-center justify-between mt-3 text-xs text-slate-500 dark:text-slate-400">
                       <span>{item.category}</span>
                       <span title={item.absoluteTime}>{item.relativeTime}</span>
                     </div>
                   </li>
                 ))
               ) : (
-                <li className="p-4 bg-slate-50 rounded-xl">
-                  <p className="text-sm text-slate-500">Недавняя активность не найдена.</p>
+                <li className="p-4 bg-slate-50 rounded-xl dark:bg-slate-800">
+                  <p className="text-sm text-slate-500 dark:text-slate-400">Недавняя активность не найдена.</p>
                 </li>
               )}
             </ul>


### PR DESCRIPTION
## Summary
- добавлен переключатель светлой и тёмной темы в макете кабинета с сохранением предпочтения пользователя
- обновлены карточки дашборда, быстрых действий и ленты активности для корректного отображения в тёмной теме

## Testing
- npm run build *(падает: в окружении недоступен пакет jotai)*

------
https://chatgpt.com/codex/tasks/task_e_68fa6ea2b5588329a4f9a51312cb6e3e