### PR TITLE
fix: адаптировать карточки кабинета к тёмной теме

### DIFF
--- a/components/cabinet/CabinetLayout.js
+++ b/components/cabinet/CabinetLayout.js
@@ -13,6 +13,8 @@ import {
   faUsers,
   faGaugeHigh,
   faSliders,
+  faMoon,
+  faSun,
 } from '@fortawesome/free-solid-svg-icons'
 import { LOCATIONS } from '@server/serverConstants'
 import isUserAdmin from '@helpers/isUserAdmin'
@@ -65,12 +67,15 @@ const CabinetLayout = ({ children, title, description, activePage }) => {
   const router = useRouter()
   const { data: session } = useSession()
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(false)
+  const [theme, setTheme] = useState('light')
+  const [isThemeInitialized, setIsThemeInitialized] = useState(false)
 
   const role = session?.user?.role ?? null
   const userName = session?.user?.name || session?.user?.username || 'Пользователь'
   const userAvatar = session?.user?.photoUrl ?? null
   const locationKey = session?.user?.location ?? null
   const locationName = normalizeLocationName(locationKey)
+  const isDarkTheme = theme === 'dark'
 
   const menuItems = useMemo(() => {
     if (isUserAdmin({ role })) {
@@ -101,116 +106,152 @@ const CabinetLayout = ({ children, title, description, activePage }) => {
     }
   }, [closeSidebarOnMobile, router])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const storedTheme = window.localStorage.getItem('cabinet-theme')
+
+    if (storedTheme === 'dark' || storedTheme === 'light') {
+      setTheme(storedTheme)
+    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark')
+    }
+
+    setIsThemeInitialized(true)
+  }, [])
+
+  useEffect(() => {
+    if (!isThemeInitialized || typeof window === 'undefined') {
+      return
+    }
+
+    window.localStorage.setItem('cabinet-theme', theme)
+    if (typeof document !== 'undefined') {
+      document.documentElement.style.colorScheme = isDarkTheme ? 'dark' : 'light'
+    }
+  }, [isDarkTheme, isThemeInitialized, theme])
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))
+  }, [])
+
   const handleSignOut = async () => {
     await signOut({ redirect: true, callbackUrl: '/' })
   }
 
   return (
-    <div className="flex min-h-screen bg-slate-100">
-      <div
-        className={`fixed inset-y-0 left-0 z-40 flex flex-col bg-white border-r border-slate-200 transition-all duration-200 md:static md:translate-x-0 md:w-64 ${
-          isSidebarExpanded ? 'w-64 translate-x-0 shadow-xl' : 'w-16 -translate-x-full md:translate-x-0'
-        }`}
-      >
-        <div className="flex items-center justify-center h-16 border-b border-slate-200">
-          <span className="text-lg font-semibold text-primary">ActQuest</span>
-        </div>
-        <nav className="flex-1 py-4 space-y-1 overflow-y-auto">
-          {menuItems.map((item) => {
-            const isActive =
-              activePage === item.id || router.pathname === item.href
-
-            return (
-              <Link key={item.id} href={item.href} legacyBehavior>
-                <a
-                  className={`flex items-center gap-4 px-4 py-3 text-sm font-medium transition-colors duration-150 ${
-                    isActive
-                      ? 'text-primary bg-blue-50 border-r-4 border-primary'
-                      : 'text-slate-600 hover:text-primary hover:bg-blue-50'
-                  } ${isSidebarExpanded ? 'justify-start' : 'justify-center md:justify-start'}`}
-                  onClick={closeSidebarOnMobile}
-                >
-                  <FontAwesomeIcon icon={item.icon} className="w-5 h-5" />
-                  <span
-                    className={`${isSidebarExpanded ? 'opacity-100' : 'opacity-0 md:opacity-100'} transition-opacity duration-150`}
-                  >
-                    {item.label}
-                  </span>
-                </a>
-              </Link>
-            )
-          })}
-        </nav>
-        <div className="px-4 py-4 border-t border-slate-200">
-          <button
-            type="button"
-            onClick={handleSignOut}
-            className="flex items-center w-full gap-3 px-3 py-2 text-sm font-medium text-slate-500 transition-colors duration-150 bg-slate-100 rounded-xl hover:text-primary hover:bg-blue-100"
-          >
-            <FontAwesomeIcon icon={faRightFromBracket} className="w-4 h-4" />
-            <span className={`${isSidebarExpanded ? 'opacity-100' : 'opacity-0 md:opacity-100'} transition-opacity duration-150`}>
-              Выйти
-            </span>
-          </button>
-        </div>
-      </div>
-
-      {isSidebarExpanded && (
+    <div className={isDarkTheme ? 'dark' : ''}>
+      <div className="flex min-h-screen bg-slate-100 dark:bg-slate-950">
         <div
-          className="fixed inset-0 z-30 bg-slate-900/40 md:hidden"
-          aria-hidden="true"
-          onClick={() => setIsSidebarExpanded(false)}
-        />
-      )}
+          className={`fixed inset-y-0 left-0 z-40 flex flex-col bg-white border-r border-slate-200 dark:bg-slate-900 dark:border-slate-800 transition-all duration-200 md:static md:translate-x-0 md:w-64 ${
+            isSidebarExpanded ? 'w-64 translate-x-0 shadow-xl' : 'w-16 -translate-x-full md:translate-x-0'
+          }`}
+        >
+          <div className="flex items-center justify-center h-16 border-b border-slate-200 dark:border-slate-800">
+            <span className="text-lg font-semibold text-primary dark:text-slate-100">ActQuest</span>
+          </div>
+          <nav className="flex-1 py-4 space-y-1 overflow-y-auto">
+            {menuItems.map((item) => {
+              const isActive = activePage === item.id || router.pathname === item.href
 
-      <div className="flex flex-col flex-1 min-h-screen">
-        <header className="sticky top-0 z-20 bg-white border-b border-slate-200">
-          <div className="flex items-center justify-between px-4 py-4 md:px-8">
-            <div className="flex items-center gap-4">
-              <button
-                type="button"
-                className="flex items-center justify-center w-10 h-10 text-slate-600 transition-colors duration-150 bg-slate-100 rounded-xl md:hidden hover:text-primary hover:bg-blue-100"
-                onClick={() => setIsSidebarExpanded((prev) => !prev)}
-                aria-label="Открыть меню"
-              >
-                <FontAwesomeIcon icon={faBars} className="w-4 h-4" />
-              </button>
-              <div>
-                <h1 className="text-xl font-semibold text-primary md:text-2xl">ActQuest</h1>
-                <p className="text-sm text-slate-500">{locationName}</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="hidden text-right md:block">
-                <p className="text-sm font-semibold text-primary">{userName}</p>
-                <p className="text-xs text-slate-500">{isUserAdmin({ role }) ? 'Администратор' : 'Участник'}</p>
-              </div>
-              {userAvatar ? (
-                <img
-                  src={userAvatar}
-                  alt={userName}
-                  className="object-cover w-10 h-10 rounded-full shadow-sm"
-                />
-              ) : (
-                <div className="flex items-center justify-center w-10 h-10 text-sm font-semibold text-white bg-primary rounded-full shadow-sm">
-                  {getInitials(userName, session?.user?.username)}
+              return (
+                <Link key={item.id} href={item.href} legacyBehavior>
+                  <a
+                    className={`flex items-center gap-4 px-4 py-3 text-sm font-medium transition-colors duration-150 ${
+                      isActive
+                        ? 'text-primary dark:text-blue-200 bg-blue-50 dark:bg-blue-500/10 border-r-4 border-primary dark:border-blue-400'
+                        : 'text-slate-600 dark:text-slate-300 hover:text-primary dark:hover:text-blue-200 hover:bg-blue-50 dark:hover:bg-blue-500/10'
+                    } ${isSidebarExpanded ? 'justify-start' : 'justify-center md:justify-start'}`}
+                    onClick={closeSidebarOnMobile}
+                  >
+                    <FontAwesomeIcon icon={item.icon} className="w-5 h-5" />
+                    <span
+                      className={`${isSidebarExpanded ? 'opacity-100' : 'opacity-0 md:opacity-100'} transition-opacity duration-150`}
+                    >
+                      {item.label}
+                    </span>
+                  </a>
+                </Link>
+              )
+            })}
+          </nav>
+          <div className="px-4 py-4 border-t border-slate-200 dark:border-slate-800">
+            <button
+              type="button"
+              onClick={handleSignOut}
+              className="flex items-center w-full gap-3 px-3 py-2 text-sm font-medium text-slate-500 transition-colors duration-150 bg-slate-100 rounded-xl hover:text-primary hover:bg-blue-100 dark:text-slate-300 dark:bg-slate-800 dark:hover:text-blue-200 dark:hover:bg-blue-500/20"
+            >
+              <FontAwesomeIcon icon={faRightFromBracket} className="w-4 h-4" />
+              <span className={`${isSidebarExpanded ? 'opacity-100' : 'opacity-0 md:opacity-100'} transition-opacity duration-150`}>
+                Выйти
+              </span>
+            </button>
+          </div>
+        </div>
+
+        {isSidebarExpanded && (
+          <div
+            className="fixed inset-0 z-30 bg-slate-900/40 md:hidden"
+            aria-hidden="true"
+            onClick={() => setIsSidebarExpanded(false)}
+          />
+        )}
+
+        <div className="flex flex-col flex-1 min-h-screen">
+          <header className="sticky top-0 z-20 bg-white border-b border-slate-200 dark:bg-slate-900 dark:border-slate-800">
+            <div className="flex items-center justify-between px-4 py-4 md:px-8">
+              <div className="flex items-center gap-4">
+                <button
+                  type="button"
+                  className="flex items-center justify-center w-10 h-10 text-slate-600 transition-colors duration-150 bg-slate-100 rounded-xl md:hidden hover:text-primary hover:bg-blue-100 dark:text-slate-300 dark:bg-slate-800 dark:hover:text-blue-200 dark:hover:bg-blue-500/20"
+                  onClick={() => setIsSidebarExpanded((prev) => !prev)}
+                  aria-label="Открыть меню"
+                >
+                  <FontAwesomeIcon icon={faBars} className="w-4 h-4" />
+                </button>
+                <div>
+                  <h1 className="text-xl font-semibold text-primary md:text-2xl dark:text-slate-100">ActQuest</h1>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">{locationName}</p>
                 </div>
-              )}
+              </div>
+              <div className="flex items-center gap-3 md:gap-4">
+                <button
+                  type="button"
+                  onClick={toggleTheme}
+                  className="flex items-center justify-center w-10 h-10 text-slate-600 transition-colors duration-150 bg-slate-100 rounded-xl hover:text-primary hover:bg-blue-100 dark:text-slate-300 dark:bg-slate-800 dark:hover:text-blue-200 dark:hover:bg-blue-500/20"
+                  aria-label={isDarkTheme ? 'Включить светлую тему' : 'Включить тёмную тему'}
+                >
+                  <FontAwesomeIcon icon={isDarkTheme ? faSun : faMoon} className="w-4 h-4" />
+                </button>
+                <div className="hidden text-right md:block">
+                  <p className="text-sm font-semibold text-primary dark:text-slate-100">{userName}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">{isUserAdmin({ role }) ? 'Администратор' : 'Участник'}</p>
+                </div>
+                {userAvatar ? (
+                  <img src={userAvatar} alt={userName} className="object-cover w-10 h-10 rounded-full shadow-sm" />
+                ) : (
+                  <div className="flex items-center justify-center w-10 h-10 text-sm font-semibold text-white bg-primary rounded-full shadow-sm dark:bg-blue-500">
+                    {getInitials(userName, session?.user?.username)}
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
-        </header>
+          </header>
 
-        <main className="flex-1 px-4 py-6 md:px-8">
-          <div className="max-w-5xl mx-auto">
-            <div className="mb-6">
-              <h2 className="text-2xl font-semibold text-primary">{title}</h2>
-              {description ? (
-                <p className="mt-1 text-sm text-slate-500">{description}</p>
-              ) : null}
+          <main className="flex-1 px-4 py-6 md:px-8">
+            <div className="max-w-5xl mx-auto">
+              <div className="mb-6">
+                <h2 className="text-2xl font-semibold text-primary dark:text-slate-100">{title}</h2>
+                {description ? (
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
+                ) : null}
+              </div>
+              <div className="space-y-6">{children}</div>
             </div>
-            <div className="space-y-6">{children}</div>
-          </div>
-        </main>
+          </main>
+        </div>
       </div>
     </div>
   )

--- a/pages/cabinet/admin/index.js
+++ b/pages/cabinet/admin/index.js
@@ -48,7 +48,7 @@ const AdminPage = () => {
           description="Доступ только для администраторов проекта."
           activePage="admin"
         >
-          <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
+          <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
             <p className="text-sm text-slate-600">
               У вас нет доступа к административным инструментам. Если вы считаете, что это ошибка,
               обратитесь к главному организатору или поддержке ActQuest.
@@ -73,7 +73,7 @@ const AdminPage = () => {
           {adminTools.map((tool) => (
             <article
               key={tool.id}
-              className="flex flex-col justify-between p-6 bg-white border border-slate-200 rounded-2xl shadow-sm"
+              className="flex flex-col justify-between p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm"
             >
               <div>
                 <h3 className="text-lg font-semibold text-primary">{tool.title}</h3>

--- a/pages/cabinet/admin/reports.js
+++ b/pages/cabinet/admin/reports.js
@@ -132,7 +132,7 @@ const ReportsPage = ({ initialReports, initialLocation, session: initialSession 
           description="Доступ ограничен: административные права отсутствуют."
           activePage="admin"
         >
-          <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
+          <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
             <p className="text-sm text-slate-600">
               У вас нет доступа к статистике проекта. Если вы считаете, что это ошибка, обратитесь к главному
               организатору.
@@ -157,7 +157,7 @@ const ReportsPage = ({ initialReports, initialLocation, session: initialSession 
           {summarySections.map((section) => (
             <article
               key={section.id}
-              className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-4"
+              className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-4"
             >
               <h2 className="text-lg font-semibold text-primary">{section.title}</h2>
               <ul className="space-y-2">
@@ -175,7 +175,7 @@ const ReportsPage = ({ initialReports, initialLocation, session: initialSession 
         </section>
 
         <section className="grid gap-6 mt-6 md:grid-cols-2">
-          <article className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-4">
+          <article className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-4">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold text-primary">Распределение ролей</h2>
               <span className="text-xs text-slate-500">
@@ -211,14 +211,14 @@ const ReportsPage = ({ initialReports, initialLocation, session: initialSession 
             )}
           </article>
 
-          <article className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-4">
+          <article className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-4">
             <h2 className="text-lg font-semibold text-primary">Топ команд по активности</h2>
             {initialReports.topTeams.length > 0 ? (
               <ul className="space-y-3">
                 {initialReports.topTeams.map((team) => (
                   <li
                     key={team.id}
-                    className="p-4 border border-slate-200 rounded-2xl flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
+                    className="p-4 border border-slate-200 dark:border-slate-700 rounded-2xl flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
                   >
                     <div>
                       <p className="text-sm font-semibold text-primary">{team.name}</p>
@@ -240,14 +240,14 @@ const ReportsPage = ({ initialReports, initialLocation, session: initialSession 
           </article>
         </section>
 
-        <section className="mt-6 p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-4">
+        <section className="mt-6 p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-4">
           <h2 className="text-lg font-semibold text-primary">Недавняя активность</h2>
           {initialReports.recentActivity.length > 0 ? (
             <ul className="space-y-3">
               {initialReports.recentActivity.map((activity) => (
                 <li
                   key={activity.id}
-                  className="p-4 border border-slate-200 rounded-2xl flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
+                  className="p-4 border border-slate-200 dark:border-slate-700 rounded-2xl flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
                 >
                   <div>
                     <p className="text-sm font-semibold text-primary">{activity.name}</p>

--- a/pages/cabinet/admin/teams.js
+++ b/pages/cabinet/admin/teams.js
@@ -430,7 +430,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
           description="Доступ ограничен: административные права отсутствуют."
           activePage="admin"
         >
-          <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
+          <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
             <p className="text-sm text-slate-600">
               У вас нет доступа к управлению командами. Если вы считаете, что это ошибка, обратитесь к главному
               организатору.
@@ -453,14 +453,14 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
       >
         <section className="grid gap-6 md:grid-cols-5">
           <div className="md:col-span-2 space-y-4">
-            <div className="p-4 bg-white border border-slate-200 rounded-2xl shadow-sm">
+            <div className="p-4 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
               <p className="text-sm font-semibold text-primary">Все команды</p>
               <p className="mt-1 text-xs text-slate-500">
                 Всего: {summary.total}. Открытых: {summary.open}. Закрытых: {summary.closed}.
               </p>
             </div>
 
-            <div className="p-4 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-3">
+            <div className="p-4 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-3">
               <div>
                 <label htmlFor="team-search" className="text-xs font-semibold text-slate-500">
                   Поиск
@@ -471,7 +471,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                   value={searchQuery}
                   onChange={(event) => setSearchQuery(event.target.value)}
                   placeholder="Введите название команды или участника"
-                  className="w-full px-3 py-2 mt-1 text-sm border rounded-xl border-slate-200 focus:border-primary focus:ring-1 focus:ring-primary"
+                  className="w-full px-3 py-2 mt-1 text-sm border rounded-xl border-slate-200 dark:border-slate-700 focus:border-primary focus:ring-1 focus:ring-primary"
                 />
               </div>
 
@@ -483,7 +483,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                   id="team-visibility-filter"
                   value={visibilityFilter}
                   onChange={(event) => setVisibilityFilter(event.target.value)}
-                  className="w-full px-3 py-2 mt-1 text-sm border rounded-xl border-slate-200 focus:border-primary focus:ring-1 focus:ring-primary"
+                  className="w-full px-3 py-2 mt-1 text-sm border rounded-xl border-slate-200 dark:border-slate-700 focus:border-primary focus:ring-1 focus:ring-primary"
                 >
                   <option value="all">Все команды</option>
                   <option value="open">Открытые</option>
@@ -502,7 +502,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                       className={`w-full text-left p-4 border rounded-2xl transition ${
                         selectedTeamId === team.id
                           ? 'border-primary bg-blue-50 shadow-sm'
-                          : 'border-slate-200 bg-white hover:border-primary hover:bg-blue-50'
+                          : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900/80 hover:border-primary hover:bg-blue-50'
                       }`}
                     >
                       <div className="flex items-center justify-between gap-3">
@@ -514,7 +514,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                           className={`text-xs font-medium px-2 py-1 rounded-full ${
                             team.open
                               ? 'bg-emerald-50 text-emerald-600 border border-emerald-200'
-                              : 'bg-slate-100 text-slate-600 border border-slate-200'
+                              : 'bg-slate-100 text-slate-600 border border-slate-200 dark:border-slate-700'
                           }`}
                         >
                           {team.open ? 'Открыта' : 'Закрыта'}
@@ -526,7 +526,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                 ))}
               </ul>
             ) : (
-              <div className="p-6 text-sm text-center text-slate-500 bg-white border border-slate-200 rounded-2xl shadow-sm">
+              <div className="p-6 text-sm text-center text-slate-500 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
                 Команды не найдены. Измените параметры фильтра или сбросьте поиск.
               </div>
             )}
@@ -553,13 +553,13 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                   </div>
                 )}
 
-                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-4">
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-4">
                   <div className="flex flex-wrap items-center gap-3">
                     <span
                       className={`px-2.5 py-1 text-xs font-semibold rounded-full border ${
                         selectedTeam.open
                           ? 'text-emerald-600 bg-emerald-50 border-emerald-200'
-                          : 'text-slate-600 bg-slate-100 border-slate-200'
+                          : 'text-slate-600 bg-slate-100 border-slate-200 dark:border-slate-700'
                       }`}
                     >
                       {selectedTeam.open ? 'Открыта для заявок' : 'Закрытый состав'}
@@ -584,7 +584,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                 </section>
 
                 <fieldset disabled={!canManageSelectedTeam} className="space-y-6 border-0 p-0 m-0">
-                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-5">
                     <div className="grid gap-4 md:grid-cols-2">
                       <div>
                         <label htmlFor="team-name" className="text-sm font-semibold text-primary">
@@ -595,7 +595,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                           type="text"
                           value={selectedTeam.name}
                           onChange={(event) => handleTeamFieldChange('name', event.target.value)}
-                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                         />
                       </div>
                       <div>
@@ -626,12 +626,12 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                         value={selectedTeam.description}
                         onChange={(event) => handleTeamFieldChange('description', event.target.value)}
                         rows={5}
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                     </div>
                   </section>
 
-                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-5">
                     <div className="flex items-center justify-between">
                       <h2 className="text-lg font-semibold text-primary">Состав команды</h2>
                       {selectedTeam.captain && (
@@ -650,7 +650,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                           return (
                             <div
                               key={member.id}
-                              className="p-4 border border-slate-200 rounded-2xl bg-white shadow-sm"
+                              className="p-4 border border-slate-200 dark:border-slate-700 rounded-2xl bg-white dark:bg-slate-900/80 shadow-sm"
                             >
                               <div className="flex flex-wrap items-start justify-between gap-3">
                                 <div>
@@ -688,7 +688,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                                       disabled={isProcessing}
                                       className={`inline-flex justify-center px-4 py-2 text-xs font-semibold rounded-xl border transition ${
                                         isProcessing
-                                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                                          ? 'border-slate-200 dark:border-slate-700 text-slate-400 cursor-not-allowed'
                                           : 'border-primary text-primary hover:bg-blue-50'
                                       }`}
                                     >
@@ -702,7 +702,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                                       disabled={isProcessing}
                                       className={`inline-flex justify-center px-4 py-2 text-xs font-semibold rounded-xl border transition ${
                                         isProcessing
-                                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                                          ? 'border-slate-200 dark:border-slate-700 text-slate-400 cursor-not-allowed'
                                           : 'border-rose-200 text-rose-600 hover:bg-rose-50'
                                       }`}
                                     >
@@ -741,7 +741,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                       disabled={!canManageSelectedTeam || !isDirty}
                       className={`inline-flex justify-center px-5 py-3 text-sm font-semibold rounded-xl border transition ${
                         !canManageSelectedTeam || !isDirty
-                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                          ? 'border-slate-200 dark:border-slate-700 text-slate-400 cursor-not-allowed'
                           : 'border-primary text-primary hover:bg-blue-50'
                       }`}
                     >
@@ -750,7 +750,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                   </div>
                 </fieldset>
 
-                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-4">
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-4">
                   <h3 className="text-base font-semibold text-primary">Игры команды</h3>
 
                   {selectedTeam.games?.length > 0 ? (
@@ -758,7 +758,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                       {selectedTeam.games.map((game) => (
                         <li
                           key={game.id}
-                          className="p-4 border border-slate-200 rounded-2xl flex flex-col gap-1 md:flex-row md:items-center md:justify-between"
+                          className="p-4 border border-slate-200 dark:border-slate-700 rounded-2xl flex flex-col gap-1 md:flex-row md:items-center md:justify-between"
                         >
                           <div>
                             <p className="text-sm font-semibold text-primary">{game.name || 'Без названия'}</p>
@@ -780,7 +780,7 @@ const AdminTeamsPage = ({ initialTeams, initialLocation, session: initialSession
                 </section>
               </div>
             ) : (
-              <div className="flex items-center justify-center h-full p-6 bg-white border border-dashed border-slate-200 rounded-2xl">
+              <div className="flex items-center justify-center h-full p-6 bg-white dark:bg-slate-900/80 border border-dashed border-slate-200 dark:border-slate-700 rounded-2xl">
                 <p className="text-sm text-slate-500">Выберите команду из списка слева, чтобы просмотреть детали.</p>
               </div>
             )}

--- a/pages/cabinet/admin/users.js
+++ b/pages/cabinet/admin/users.js
@@ -365,7 +365,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
           description="Доступ ограничен: административные права отсутствуют."
           activePage="admin"
         >
-          <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
+          <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
             <p className="text-sm text-slate-600">
               У вас нет доступа к управлению пользователями. Если вы считаете, что это ошибка, обратитесь к
               главному организатору.
@@ -388,14 +388,14 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
       >
         <section className="grid gap-6 md:grid-cols-5">
           <div className="md:col-span-2 space-y-4">
-            <div className="p-4 bg-white border border-slate-200 rounded-2xl shadow-sm">
+            <div className="p-4 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
               <p className="text-sm font-semibold text-primary">Все пользователи</p>
               <p className="mt-1 text-xs text-slate-500">
                 Всего: {users.length}. Выберите участника, чтобы просмотреть детали и обновить его роль.
               </p>
             </div>
 
-            <div className="p-4 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-3">
+            <div className="p-4 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-3">
               <div>
                 <label htmlFor="user-search" className="text-xs font-semibold text-slate-500">
                   Поиск
@@ -406,7 +406,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                   value={searchQuery}
                   onChange={(event) => setSearchQuery(event.target.value)}
                   placeholder="Введите имя, ник или Telegram ID"
-                  className="w-full px-3 py-2 mt-1 text-sm border rounded-xl border-slate-200 focus:border-primary focus:ring-1 focus:ring-primary"
+                  className="w-full px-3 py-2 mt-1 text-sm border rounded-xl border-slate-200 dark:border-slate-700 focus:border-primary focus:ring-1 focus:ring-primary"
                 />
               </div>
 
@@ -418,7 +418,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                   id="user-role-filter"
                   value={roleFilter}
                   onChange={(event) => setRoleFilter(event.target.value)}
-                  className="w-full px-3 py-2 mt-1 text-sm border rounded-xl border-slate-200 focus:border-primary focus:ring-1 focus:ring-primary"
+                  className="w-full px-3 py-2 mt-1 text-sm border rounded-xl border-slate-200 dark:border-slate-700 focus:border-primary focus:ring-1 focus:ring-primary"
                 >
                   {filterOptions.map((option) => (
                     <option key={option.value} value={option.value}>
@@ -445,7 +445,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                         className={`w-full text-left p-4 border rounded-2xl transition ${
                           isActive
                             ? 'border-primary bg-blue-50 shadow-sm'
-                            : 'border-slate-200 bg-white hover:border-primary hover:bg-blue-50'
+                            : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900/80 hover:border-primary hover:bg-blue-50'
                         }`}
                       >
                         <div className="flex items-start justify-between gap-3">
@@ -473,7 +473,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                 })}
               </ul>
             ) : (
-              <div className="p-6 text-sm text-center text-slate-500 bg-white border border-slate-200 rounded-2xl shadow-sm">
+              <div className="p-6 text-sm text-center text-slate-500 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
                 Пользователи не найдены. Измените параметры фильтра или сбросьте поиск.
               </div>
             )}
@@ -500,7 +500,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                   </div>
                 )}
 
-                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-6">
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-6">
                   <div>
                     <h2 className="text-lg font-semibold text-primary">
                       {selectedUser.name || 'Без имени'}
@@ -520,7 +520,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                       <p className="text-xs text-emerald-600">Игры</p>
                       <p className="mt-1 text-xl font-semibold text-emerald-700">{selectedUser.gamesCount}</p>
                     </div>
-                    <div className="p-4 bg-slate-50 border border-slate-200 rounded-xl">
+                    <div className="p-4 bg-slate-50 border border-slate-200 dark:border-slate-700 rounded-xl">
                       <p className="text-xs text-slate-600">Последнее обновление</p>
                       <p className="mt-1 text-sm text-slate-700">
                         {selectedUser.updatedAt
@@ -538,7 +538,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                       id="user-role"
                       value={selectedUser.role}
                       onChange={(event) => handleRoleChange(event.target.value)}
-                      className="w-full px-4 py-3 mt-2 text-sm border rounded-xl border-slate-200 focus:border-primary focus:ring-1 focus:ring-primary"
+                      className="w-full px-4 py-3 mt-2 text-sm border rounded-xl border-slate-200 dark:border-slate-700 focus:border-primary focus:ring-1 focus:ring-primary"
                     >
                       {roleOptions.map((option) => (
                         <option key={option.value} value={option.value}>
@@ -567,7 +567,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                       disabled={!isDirty}
                       className={`inline-flex justify-center px-5 py-3 text-sm font-semibold rounded-xl border transition ${
                         !isDirty
-                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                          ? 'border-slate-200 dark:border-slate-700 text-slate-400 cursor-not-allowed'
                           : 'border-primary text-primary hover:bg-blue-50'
                       }`}
                     >
@@ -576,7 +576,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                   </div>
                 </section>
 
-                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-4">
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-4">
                   <h3 className="text-base font-semibold text-primary">Команды пользователя</h3>
 
                   {selectedUser.teams.length > 0 ? (
@@ -584,7 +584,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                       {selectedUser.teams.map((team) => (
                         <li
                           key={team.id}
-                          className="p-4 border border-slate-200 rounded-2xl flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
+                          className="p-4 border border-slate-200 dark:border-slate-700 rounded-2xl flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
                         >
                           <div>
                             <p className="text-sm font-semibold text-primary">{team.name || 'Без названия'}</p>
@@ -607,7 +607,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                   )}
                 </section>
 
-                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-4">
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-4">
                   <h3 className="text-base font-semibold text-primary">Дополнительная информация</h3>
 
                   <div className="grid gap-3 md:grid-cols-2">
@@ -654,7 +654,7 @@ const ManageUsersPage = ({ initialUsers, initialLocation, session: initialSessio
                 </section>
               </div>
             ) : (
-              <div className="flex items-center justify-center h-full p-6 bg-white border border-dashed border-slate-200 rounded-2xl">
+              <div className="flex items-center justify-center h-full p-6 bg-white dark:bg-slate-900/80 border border-dashed border-slate-200 dark:border-slate-700 rounded-2xl">
                 <p className="text-sm text-slate-500">Выберите пользователя из списка слева, чтобы просмотреть детали.</p>
               </div>
             )}

--- a/pages/cabinet/games.js
+++ b/pages/cabinet/games.js
@@ -448,7 +448,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
       >
         <section className="grid gap-6 md:grid-cols-5">
           <div className="md:col-span-2 space-y-4">
-            <div className="p-4 bg-white border border-slate-200 rounded-2xl shadow-sm">
+            <div className="p-4 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
               <p className="text-sm font-semibold text-primary">Ваши игры</p>
               <p className="mt-1 text-xs text-slate-500">
                 Выберите игру для редактирования основных настроек и финансовой информации.
@@ -477,7 +477,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                         className={`w-full text-left p-4 border rounded-2xl transition hover:border-primary hover:bg-blue-50 ${
                           selectedGameId === game.id
                             ? 'border-primary bg-blue-50 shadow-sm'
-                            : 'border-slate-200 bg-white'
+                            : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900/80'
                         }`}
                       >
                         <p className="text-sm font-semibold text-primary">
@@ -495,7 +495,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                 })}
               </ul>
             ) : (
-              <div className="p-6 text-sm text-center text-slate-500 bg-white border border-slate-200 rounded-2xl shadow-sm">
+              <div className="p-6 text-sm text-center text-slate-500 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
                 Для выбранного города пока нет игр. Создайте сценарий в телеграм-боте, чтобы он появился здесь.
               </div>
             )}
@@ -504,7 +504,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
           <div className="md:col-span-3">
             {selectedGame ? (
               <div className="space-y-6">
-                <div className="p-5 bg-white border border-slate-200 rounded-2xl shadow-sm">
+                <div className="p-5 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
                   <div className="flex flex-wrap items-center gap-3">
                     <span className="px-2.5 py-1 text-xs font-semibold text-primary bg-blue-50 rounded-full">
                       {getGameStatusLabel(selectedGame.status)}
@@ -552,7 +552,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                 )}
 
                 <fieldset disabled={!canEditSelectedGame} className="space-y-6 border-0 p-0 m-0">
-                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-5">
                   <div className="grid gap-4 md:grid-cols-2">
                     <div>
                       <label htmlFor="game-title" className="text-sm font-semibold text-primary">
@@ -565,7 +565,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                         onChange={(event) =>
                           updateSelectedGame({ name: event.target.value })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                     </div>
                     <div>
@@ -578,7 +578,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                         onChange={(event) =>
                           updateSelectedGame({ status: event.target.value })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       >
                         {GAME_STATUS_OPTIONS.map((option) => (
                           <option key={option.value} value={option.value}>
@@ -600,7 +600,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                         onChange={(event) =>
                           updateSelectedGame({ type: event.target.value })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       >
                         {GAME_TYPE_OPTIONS.map((option) => (
                           <option key={option.value} value={option.value}>
@@ -628,7 +628,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                               : null,
                           })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                     </div>
                   </div>
@@ -660,7 +660,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                         onChange={(event) =>
                           updateSelectedGame({ startingPlace: event.target.value })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                     </div>
                     <div>
@@ -674,7 +674,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                         onChange={(event) =>
                           updateSelectedGame({ finishingPlace: event.target.value })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                     </div>
                   </div>
@@ -690,7 +690,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                         updateSelectedGame({ description: event.target.value })
                       }
                       rows={5}
-                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                     />
                   </div>
 
@@ -705,19 +705,19 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                       onChange={(event) =>
                         updateSelectedGame({ image: event.target.value })
                       }
-                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                      className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                     />
                     {selectedGame.image && (
                       <img
                         src={selectedGame.image}
                         alt={selectedGame.name || 'Обложка игры'}
-                        className="object-cover w-full h-40 mt-3 rounded-xl border border-slate-200"
+                        className="object-cover w-full h-40 mt-3 rounded-xl border border-slate-200 dark:border-slate-700"
                       />
                     )}
                   </div>
                   </section>
 
-                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-5">
                   <h2 className="text-lg font-semibold text-primary">Настройки заданий и подсказок</h2>
                   <div className="grid gap-4 md:grid-cols-2">
                     <div>
@@ -734,7 +734,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                             taskDuration: toSeconds(event.target.value),
                           })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                     </div>
                     <div>
@@ -751,7 +751,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                             cluesDuration: toSeconds(event.target.value),
                           })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                       <p className="mt-1 text-xs text-slate-500">
                         Укажите 0, чтобы отключить автоматическую выдачу подсказок.
@@ -772,7 +772,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                             clueEarlyAccessMode: event.target.value,
                           })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       >
                         {CLUE_EARLY_MODE_OPTIONS.map((option) => (
                           <option key={option.value} value={option.value}>
@@ -797,7 +797,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                             clueEarlyPenalty: toSeconds(event.target.value),
                           })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                     </div>
                   </div>
@@ -817,7 +817,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                             breakDuration: toSeconds(event.target.value),
                           })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                     </div>
                     <div>
@@ -843,7 +843,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                                 : toSeconds(event.target.value),
                           })
                         }
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                     </div>
                   </div>
@@ -867,7 +867,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                               ],
                             })
                           }
-                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                         />
                       </div>
                       <div>
@@ -887,7 +887,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                               ],
                             })
                           }
-                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                         />
                       </div>
                     </div>
@@ -936,7 +936,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                   </div>
                   </section>
 
-                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-5">
                   <h2 className="text-lg font-semibold text-primary">Публикация и результаты</h2>
                   <div className="grid gap-3 md:grid-cols-2">
                     <label className="flex items-center gap-2 text-sm text-slate-600">
@@ -986,7 +986,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                   </div>
                   </section>
 
-                  <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                  <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-5">
                   <div className="flex items-center justify-between">
                     <h2 className="text-lg font-semibold text-primary">Стоимость участия</h2>
                     <button
@@ -1003,7 +1003,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                       {selectedGame.prices.map((price) => (
                         <div
                           key={price.id}
-                          className="grid gap-3 md:grid-cols-[2fr_1fr_auto] items-center p-4 border border-slate-200 rounded-2xl"
+                          className="grid gap-3 md:grid-cols-[2fr_1fr_auto] items-center p-4 border border-slate-200 dark:border-slate-700 rounded-2xl"
                         >
                           <input
                             type="text"
@@ -1012,7 +1012,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                               handlePriceChange(price.id, 'name', event.target.value)
                             }
                             placeholder="Название тарифа"
-                            className="w-full px-4 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                            className="w-full px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                           />
                           <input
                             type="number"
@@ -1022,7 +1022,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                               handlePriceChange(price.id, 'price', event.target.value)
                             }
                             placeholder="Стоимость"
-                            className="w-full px-4 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                            className="w-full px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                           />
                           <button
                             type="button"
@@ -1041,7 +1041,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                   )}
                 </section>
 
-                <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm space-y-5">
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-5">
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <h2 className="text-lg font-semibold text-primary">Финансы игры</h2>
                     <button
@@ -1058,14 +1058,14 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                       {selectedGame.finances.map((entry) => (
                         <div
                           key={entry.id}
-                          className="grid gap-3 md:grid-cols-[1fr_1fr_1fr_auto] items-center p-4 border border-slate-200 rounded-2xl"
+                          className="grid gap-3 md:grid-cols-[1fr_1fr_1fr_auto] items-center p-4 border border-slate-200 dark:border-slate-700 rounded-2xl"
                         >
                           <select
                             value={entry.type}
                             onChange={(event) =>
                               handleFinanceChange(entry.id, 'type', event.target.value)
                             }
-                            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                            className="w-full px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                           >
                             <option value="income">Доход</option>
                             <option value="expense">Расход</option>
@@ -1078,7 +1078,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                               handleFinanceChange(entry.id, 'sum', event.target.value)
                             }
                             placeholder="Сумма"
-                            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                            className="w-full px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                           />
                           <input
                             type="date"
@@ -1086,7 +1086,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                             onChange={(event) =>
                               handleFinanceChange(entry.id, 'date', event.target.value)
                             }
-                            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                            className="w-full px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                           />
                           <button
                             type="button"
@@ -1103,7 +1103,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                                 handleFinanceChange(entry.id, 'description', event.target.value)
                               }
                               placeholder="Комментарий"
-                              className="w-full px-3 py-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                              className="w-full px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                             />
                           </div>
                         </div>
@@ -1115,7 +1115,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                     </p>
                   )}
 
-                  <div className="p-4 bg-slate-50 border border-slate-200 rounded-2xl">
+                  <div className="p-4 bg-slate-50 border border-slate-200 dark:border-slate-700 rounded-2xl">
                     <p className="text-sm text-slate-600">
                       Доходы: <span className="font-semibold">{currencyFormatter.format(financesSummary.income)}</span>
                     </p>
@@ -1147,7 +1147,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                       disabled={!canEditSelectedGame || !isDirty}
                       className={`inline-flex justify-center px-5 py-3 text-sm font-semibold rounded-xl border transition ${
                         !canEditSelectedGame || !isDirty
-                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                          ? 'border-slate-200 dark:border-slate-700 text-slate-400 cursor-not-allowed'
                           : 'border-primary text-primary hover:bg-blue-50'
                       }`}
                     >
@@ -1157,7 +1157,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                 </fieldset>
               </div>
             ) : (
-              <div className="flex items-center justify-center h-full p-6 bg-white border border-dashed rounded-2xl border-slate-200">
+              <div className="flex items-center justify-center h-full p-6 bg-white dark:bg-slate-900/80 border border-dashed rounded-2xl border-slate-200 dark:border-slate-700">
                 <p className="text-sm text-slate-500">Выберите игру из списка слева, чтобы начать редактирование.</p>
               </div>
             )}

--- a/pages/cabinet/index.js
+++ b/pages/cabinet/index.js
@@ -151,7 +151,7 @@ const CabinetDashboard = ({
           </p>
           <a
             href="/cabinet/login"
-          className="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold text-slate-900 bg-white rounded-xl"
+              className="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold text-slate-900 dark:text-slate-100 bg-white dark:bg-slate-900/80 rounded-xl"
         >
             Перейти к авторизации
           </a>
@@ -174,51 +174,55 @@ const CabinetDashboard = ({
           {normalizedStats.map((stat) => (
             <article
               key={stat.id}
-              className="p-5 transition-shadow bg-white border border-slate-200 rounded-2xl shadow-sm hover:shadow-md"
+              className="p-5 transition-shadow bg-white border border-slate-200 rounded-2xl shadow-sm hover:shadow-md dark:bg-slate-900/80 dark:border-slate-700 dark:hover:shadow-lg"
             >
-              <p className="text-sm font-medium text-slate-500">{stat.title}</p>
-              <p className="mt-3 text-3xl font-semibold text-primary">{stat.value}</p>
-              <p className="mt-2 text-xs font-medium text-slate-500">{stat.description}</p>
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">{stat.title}</p>
+              <p className="mt-3 text-3xl font-semibold text-primary dark:text-slate-100">{stat.value}</p>
+              <p className="mt-2 text-xs font-medium text-slate-500 dark:text-slate-400">{stat.description}</p>
             </article>
           ))}
         </section>
 
         <section className="grid gap-6 md:grid-cols-5">
-          <div className="md:col-span-3 p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
-            <h3 className="text-lg font-semibold text-primary">Быстрые действия</h3>
-            <p className="mt-1 text-sm text-slate-500">
+          <div className="md:col-span-3 p-6 bg-white border border-slate-200 rounded-2xl shadow-sm dark:bg-slate-900/80 dark:border-slate-700">
+            <h3 className="text-lg font-semibold text-primary dark:text-slate-100">Быстрые действия</h3>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               Сосредоточьтесь на задачах — переходите к нужным разделам без лишних шагов.
             </p>
             <div className="mt-4 space-y-4">
               {quickActions.map((action) => (
-                <a key={action.id} href={action.href} className="block p-4 transition bg-slate-50 rounded-xl hover:bg-blue-50">
-                  <p className="text-sm font-semibold text-primary">{action.title}</p>
-                  <p className="mt-1 text-xs text-slate-500">{action.description}</p>
+                <a
+                  key={action.id}
+                  href={action.href}
+                  className="block p-4 transition bg-slate-50 rounded-xl hover:bg-blue-50 dark:bg-slate-800 dark:hover:bg-blue-500/10"
+                >
+                  <p className="text-sm font-semibold text-primary dark:text-slate-100">{action.title}</p>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{action.description}</p>
                 </a>
               ))}
             </div>
           </div>
 
-          <div className="md:col-span-2 p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
-            <h3 className="text-lg font-semibold text-primary">Лента активности</h3>
-            <p className="mt-1 text-sm text-slate-500">
+          <div className="md:col-span-2 p-6 bg-white border border-slate-200 rounded-2xl shadow-sm dark:bg-slate-900/80 dark:border-slate-700">
+            <h3 className="text-lg font-semibold text-primary dark:text-slate-100">Лента активности</h3>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               Последние изменения, которые произошли в вашем кабинете.
             </p>
             <ul className="mt-4 space-y-4">
               {activityItems.length > 0 ? (
                 activityItems.map((item) => (
-                  <li key={item.id} className="p-4 bg-slate-50 rounded-xl">
-                    <p className="text-sm font-semibold text-primary">{item.title}</p>
-                    <p className="mt-2 text-xs text-slate-500">{item.details}</p>
-                    <div className="flex items-center justify-between mt-3 text-xs text-slate-500">
+                  <li key={item.id} className="p-4 bg-slate-50 rounded-xl dark:bg-slate-800">
+                    <p className="text-sm font-semibold text-primary dark:text-slate-100">{item.title}</p>
+                    <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">{item.details}</p>
+                    <div className="flex items-center justify-between mt-3 text-xs text-slate-500 dark:text-slate-400">
                       <span>{item.category}</span>
                       <span title={item.absoluteTime}>{item.relativeTime}</span>
                     </div>
                   </li>
                 ))
               ) : (
-                <li className="p-4 bg-slate-50 rounded-xl">
-                  <p className="text-sm text-slate-500">Недавняя активность не найдена.</p>
+                <li className="p-4 bg-slate-50 rounded-xl dark:bg-slate-800">
+                  <p className="text-sm text-slate-500 dark:text-slate-400">Недавняя активность не найдена.</p>
                 </li>
               )}
             </ul>
@@ -233,7 +237,7 @@ const CabinetDashboard = ({
           <div className="flex flex-col gap-3 mt-6 md:flex-row">
             <a
               href="/cabinet/games"
-              className="inline-flex items-center justify-center px-5 py-3 text-sm font-semibold text-blue-700 bg-white rounded-xl shadow-sm"
+              className="inline-flex items-center justify-center px-5 py-3 text-sm font-semibold text-blue-700 dark:text-blue-200 bg-white dark:bg-slate-900/80 rounded-xl shadow-sm"
             >
               Перейти к списку игр
             </a>

--- a/pages/cabinet/login.js
+++ b/pages/cabinet/login.js
@@ -286,19 +286,19 @@ const CabinetLoginPage = ({ authCallbackUrl, authCallbackSource }) => {
               </p>
               <ul className="space-y-3 text-sm text-slate-200 md:text-base">
                 <li className="flex items-start gap-3">
-                  <span className="inline-flex items-center justify-center flex-none w-8 h-8 text-sm font-semibold text-slate-900 bg-white rounded-full">
+                  <span className="inline-flex items-center justify-center flex-none w-8 h-8 text-sm font-semibold text-slate-900 dark:text-slate-100 bg-white dark:bg-slate-900/80 rounded-full">
                     1
                   </span>
                   <span>Выберите игровой регион, чтобы подключить нужную базу данных ActQuest.</span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <span className="inline-flex items-center justify-center flex-none w-8 h-8 text-sm font-semibold text-slate-900 bg-white rounded-full">
+                  <span className="inline-flex items-center justify-center flex-none w-8 h-8 text-sm font-semibold text-slate-900 dark:text-slate-100 bg-white dark:bg-slate-900/80 rounded-full">
                     2
                   </span>
                   <span>Подтвердите вход через Telegram — мы сверим данные с ботом и подготовим рабочую сессию.</span>
                 </li>
                 <li className="flex items-start gap-3">
-                  <span className="inline-flex items-center justify-center flex-none w-8 h-8 text-sm font-semibold text-slate-900 bg-white rounded-full">
+                  <span className="inline-flex items-center justify-center flex-none w-8 h-8 text-sm font-semibold text-slate-900 dark:text-slate-100 bg-white dark:bg-slate-900/80 rounded-full">
                     3
                   </span>
                   <span>Вернём вас в нужный раздел кабинета и подгрузим все связанные данные.</span>
@@ -306,7 +306,7 @@ const CabinetLoginPage = ({ authCallbackUrl, authCallbackSource }) => {
               </ul>
             </div>
 
-            <div className="p-8 bg-white rounded-3xl shadow-2xl">
+            <div className="p-8 bg-white dark:bg-slate-900/80 rounded-3xl shadow-2xl">
               <h2 className="text-2xl font-semibold text-primary">Войти в кабинет</h2>
               <p className="mt-2 text-sm text-slate-500">{callbackDescription}</p>
               {authCallbackSource ? (
@@ -319,7 +319,7 @@ const CabinetLoginPage = ({ authCallbackUrl, authCallbackSource }) => {
                 <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
                   Игровой регион
                   <select
-                    className="px-4 py-3 text-base transition border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    className="px-4 py-3 text-base transition border border-slate-200 dark:border-slate-700 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary/40"
                     value={location}
                     onChange={(event) => setLocation(event.target.value)}
                     disabled={isAuthenticating}
@@ -336,7 +336,7 @@ const CabinetLoginPage = ({ authCallbackUrl, authCallbackSource }) => {
                   <div ref={widgetContainerRef} className="flex items-center justify-center w-full h-20" />
                   {!botName ? (
                     <div className="px-4 py-3 text-xs text-center text-slate-500 bg-slate-100 rounded-xl">
-                      Укажите переменную окружения <code className="px-1 bg-white rounded">NEXT_PUBLIC_TELEGRAM_{location.toUpperCase()}_BOT_NAME</code>, чтобы включить авторизацию.
+                      Укажите переменную окружения <code className="px-1 bg-white dark:bg-slate-900/80 rounded">NEXT_PUBLIC_TELEGRAM_{location.toUpperCase()}_BOT_NAME</code>, чтобы включить авторизацию.
                     </div>
                   ) : null}
                   {isTestAuthEnabled ? (

--- a/pages/cabinet/profile.js
+++ b/pages/cabinet/profile.js
@@ -142,7 +142,7 @@ const ProfilePage = ({ initialProfile }) => {
         description="Обновите контакты, чтобы участники и коллеги могли быстро связаться с вами."
         activePage="profile"
       >
-        <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
+        <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div className="grid gap-4 md:grid-cols-2">
               <div>
@@ -154,7 +154,7 @@ const ProfilePage = ({ initialProfile }) => {
                   type="text"
                   value={formState.name}
                   onChange={(event) => handleChange('name', event.target.value)}
-                  className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                  className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                 />
               </div>
 
@@ -167,7 +167,7 @@ const ProfilePage = ({ initialProfile }) => {
                   type="text"
                   value={formState.username ?? ''}
                   onChange={(event) => handleChange('username', event.target.value)}
-                  className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                  className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                   placeholder="Например, quest_master"
                 />
               </div>
@@ -182,7 +182,7 @@ const ProfilePage = ({ initialProfile }) => {
                 type="tel"
                 value={formState.phone}
                 onChange={(event) => handleChange('phone', event.target.value)}
-                className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                 placeholder="+7 900 000-00-00"
               />
             </div>
@@ -196,7 +196,7 @@ const ProfilePage = ({ initialProfile }) => {
                 value={formState.about}
                 onChange={(event) => handleChange('about', event.target.value)}
                 rows={5}
-                className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                 placeholder="Расскажите об опыте, любимых форматах и роли в команде."
               />
             </div>
@@ -215,7 +215,7 @@ const ProfilePage = ({ initialProfile }) => {
                       className={`px-4 py-2 text-sm font-semibold rounded-xl transition ${
                         isActive
                           ? 'text-white bg-primary shadow-sm'
-                          : 'text-slate-600 border border-slate-200 hover:border-primary hover:text-primary'
+                          : 'text-slate-600 border border-slate-200 dark:border-slate-700 hover:border-primary hover:text-primary'
                       }`}
                     >
                       {preference}

--- a/pages/cabinet/settings.js
+++ b/pages/cabinet/settings.js
@@ -106,7 +106,7 @@ const SettingsPage = ({ initialSiteSettings }) => {
           description="Обновление публичной информации доступно только администраторам."
           activePage="settings"
         >
-          <section className="p-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
+          <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
             <p className="text-sm text-slate-600">
               У вас нет прав на изменение общих настроек. Свяжитесь с администратором проекта, чтобы получить доступ.
             </p>
@@ -126,7 +126,7 @@ const SettingsPage = ({ initialSiteSettings }) => {
         description="Настройте основные контакты, уведомления и режимы доступа."
         activePage="settings"
       >
-        <section className="p-6 space-y-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
+        <section className="p-6 space-y-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
           <div className="grid gap-4 md:grid-cols-2">
             <div>
               <label htmlFor="settings-support-phone" className="text-sm font-semibold text-primary">
@@ -137,7 +137,7 @@ const SettingsPage = ({ initialSiteSettings }) => {
                 type="tel"
                 value={siteSettings.supportPhone}
                 onChange={(event) => handleSettingsChange('supportPhone', event.target.value)}
-                className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                 placeholder="Например, +7 (900) 000-00-00"
               />
             </div>
@@ -150,7 +150,7 @@ const SettingsPage = ({ initialSiteSettings }) => {
                 type="url"
                 value={siteSettings.chatUrl}
                 onChange={(event) => handleSettingsChange('chatUrl', event.target.value)}
-                className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                 placeholder="https://t.me/actquest"
               />
             </div>
@@ -165,7 +165,7 @@ const SettingsPage = ({ initialSiteSettings }) => {
               value={siteSettings.announcement}
               onChange={(event) => handleSettingsChange('announcement', event.target.value)}
               rows={5}
-              className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+              className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
             />
           </div>
 

--- a/pages/cabinet/teams.js
+++ b/pages/cabinet/teams.js
@@ -441,7 +441,7 @@ const TeamsPage = ({
       >
         <section className="grid gap-6 md:grid-cols-5">
           <div className="space-y-4 md:col-span-2">
-            <div className="p-4 bg-white border shadow-sm border-slate-200 rounded-2xl">
+            <div className="p-4 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl">
               <p className="text-sm font-semibold text-primary">Ваши команды</p>
               <p className="mt-1 text-xs text-slate-500">
                 Выберите команду, чтобы просмотреть состав и изменить основные
@@ -459,7 +459,7 @@ const TeamsPage = ({
                       className={`w-full text-left p-4 border rounded-2xl transition hover:border-primary hover:bg-blue-50 ${
                         selectedTeamId === team.id
                           ? 'border-primary bg-blue-50 shadow-sm'
-                          : 'border-slate-200 bg-white'
+                          : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900/80'
                       }`}
                     >
                       <div className="flex items-center justify-between gap-3">
@@ -470,7 +470,7 @@ const TeamsPage = ({
                           className={`text-xs font-medium px-2 py-1 rounded-full ${
                             team.open
                               ? 'bg-emerald-50 text-emerald-600 border border-emerald-200'
-                              : 'bg-slate-100 text-slate-600 border border-slate-200'
+                              : 'bg-slate-100 text-slate-600 border border-slate-200 dark:border-slate-700'
                           }`}
                         >
                           {team.open ? 'Открыта' : 'Закрыта'}
@@ -489,7 +489,7 @@ const TeamsPage = ({
                 ))}
               </ul>
             ) : (
-              <div className="p-6 text-sm text-center bg-white border shadow-sm text-slate-500 border-slate-200 rounded-2xl">
+              <div className="p-6 text-sm text-center bg-white dark:bg-slate-900/80 border shadow-sm text-slate-500 border-slate-200 dark:border-slate-700 rounded-2xl">
                 У вас пока нет команд. Создайте команду в телеграм-боте, чтобы
                 она появилась в списке.
               </div>
@@ -499,13 +499,13 @@ const TeamsPage = ({
           <div className="md:col-span-3">
             {selectedTeam ? (
               <div className="space-y-6">
-                <div className="p-5 bg-white border shadow-sm border-slate-200 rounded-2xl">
+                <div className="p-5 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl">
                   <div className="flex flex-wrap items-center gap-3">
                     <span
                       className={`px-2.5 py-1 text-xs font-semibold rounded-full border ${
                         selectedTeam.open
                           ? 'text-emerald-600 bg-emerald-50 border-emerald-200'
-                          : 'text-slate-600 bg-slate-100 border-slate-200'
+                          : 'text-slate-600 bg-slate-100 border-slate-200 dark:border-slate-700'
                       }`}
                     >
                       {selectedTeam.open
@@ -556,7 +556,7 @@ const TeamsPage = ({
                   disabled={!canManageSelectedTeam}
                   className="p-0 m-0 space-y-6 border-0"
                 >
-                  <section className="p-6 space-y-5 bg-white border shadow-sm border-slate-200 rounded-2xl">
+                  <section className="p-6 space-y-5 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl">
                     <div className="grid gap-4 md:grid-cols-2">
                       <div>
                         <label
@@ -572,7 +572,7 @@ const TeamsPage = ({
                           onChange={(event) =>
                             handleTeamFieldChange('name', event.target.value)
                           }
-                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                          className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                         />
                       </div>
                       <div>
@@ -619,12 +619,12 @@ const TeamsPage = ({
                           )
                         }
                         rows={5}
-                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 rounded-xl focus:border-primary focus:outline-none"
+                        className="w-full px-4 py-3 mt-2 text-sm border border-slate-200 dark:border-slate-700 rounded-xl focus:border-primary focus:outline-none"
                       />
                     </div>
                   </section>
 
-                  <section className="p-6 space-y-5 bg-white border shadow-sm border-slate-200 rounded-2xl">
+                  <section className="p-6 space-y-5 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl">
                     <div className="flex items-center justify-between">
                       <h2 className="text-lg font-semibold text-primary">
                         Состав команды
@@ -645,7 +645,7 @@ const TeamsPage = ({
                           return (
                             <div
                               key={member.id}
-                              className="p-4 bg-white border shadow-sm border-slate-200 rounded-2xl"
+                              className="p-4 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl"
                             >
                               <div className="flex flex-wrap items-start justify-between gap-3">
                                 <div>
@@ -691,7 +691,7 @@ const TeamsPage = ({
                                       disabled={isProcessing}
                                       className={`inline-flex justify-center px-4 py-2 text-xs font-semibold rounded-xl border transition ${
                                         isProcessing
-                                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                                          ? 'border-slate-200 dark:border-slate-700 text-slate-400 cursor-not-allowed'
                                           : 'border-primary text-primary hover:bg-blue-50'
                                       }`}
                                     >
@@ -707,7 +707,7 @@ const TeamsPage = ({
                                       disabled={isProcessing}
                                       className={`inline-flex justify-center px-4 py-2 text-xs font-semibold rounded-xl border transition ${
                                         isProcessing
-                                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                                          ? 'border-slate-200 dark:border-slate-700 text-slate-400 cursor-not-allowed'
                                           : 'border-rose-200 text-rose-600 hover:bg-rose-50'
                                       }`}
                                     >
@@ -728,7 +728,7 @@ const TeamsPage = ({
                     )}
                   </section>
 
-                  <section className="p-6 space-y-4 bg-white border shadow-sm border-slate-200 rounded-2xl">
+                  <section className="p-6 space-y-4 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl">
                     <h2 className="text-lg font-semibold text-primary">
                       Игры команды
                     </h2>
@@ -737,7 +737,7 @@ const TeamsPage = ({
                         {selectedTeam.games.map((game) => (
                           <li
                             key={game.id}
-                            className="p-4 border border-slate-200 rounded-2xl bg-slate-50"
+                            className="p-4 border border-slate-200 dark:border-slate-700 rounded-2xl bg-slate-50"
                           >
                             <div className="flex flex-wrap items-center justify-between gap-3">
                               <p className="text-sm font-semibold text-primary">
@@ -796,7 +796,7 @@ const TeamsPage = ({
                       disabled={!canManageSelectedTeam || !isDirty}
                       className={`inline-flex justify-center px-5 py-3 text-sm font-semibold rounded-xl border transition ${
                         !canManageSelectedTeam || !isDirty
-                          ? 'border-slate-200 text-slate-400 cursor-not-allowed'
+                          ? 'border-slate-200 dark:border-slate-700 text-slate-400 cursor-not-allowed'
                           : 'border-primary text-primary hover:bg-blue-50'
                       }`}
                     >
@@ -806,7 +806,7 @@ const TeamsPage = ({
                 </fieldset>
               </div>
             ) : (
-              <div className="flex items-center justify-center h-full p-6 bg-white border border-dashed border-slate-200 rounded-2xl">
+              <div className="flex items-center justify-center h-full p-6 bg-white dark:bg-slate-900/80 border border-dashed border-slate-200 dark:border-slate-700 rounded-2xl">
                 <p className="text-sm text-slate-500">
                   Выберите команду из списка слева, чтобы просмотреть детали.
                 </p>


### PR DESCRIPTION
## Summary
- добавлены тёмные варианты фона и рамок карточек на страницах кабинета, чтобы устранить белые блоки при тёмной теме
- обновлены кнопки и маркеры с учётом тёмной темы, чтобы сохранить читабельность текста

## Testing
- npm run build *(падает: отсутствует зависимость jotai)*

------
https://chatgpt.com/codex/tasks/task_e_68fa6ea2b5588329a4f9a51312cb6e3e