### PR TITLE
Add modal editing for cabinet games and teams

### DIFF
--- a/components/Modal.js
+++ b/components/Modal.js
@@ -1,0 +1,80 @@
+import { useEffect } from 'react'
+import PropTypes from 'prop-types'
+
+const Modal = ({
+  isOpen,
+  title,
+  children,
+  onClose,
+  footer,
+}) => {
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onClose?.()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen) {
+    return null
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+      <div
+        className="absolute inset-0 bg-slate-900/50"
+        onClick={() => onClose?.()}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="relative z-10 w-full max-w-5xl max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-xl dark:bg-slate-900/95"
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-slate-100 px-6 py-4 dark:border-slate-700/60">
+          <h2 className="text-lg font-semibold text-primary">{title}</h2>
+          <button
+            type="button"
+            onClick={() => onClose?.()}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 dark:border-slate-700 dark:hover:bg-slate-800"
+            aria-label="Закрыть"
+          >
+            ×
+          </button>
+        </div>
+        <div className="px-6 py-5">{children}</div>
+        {footer ? (
+          <div className="flex flex-col gap-3 px-6 pb-6 sm:flex-row sm:items-center sm:justify-end">
+            {footer}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+Modal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  onClose: PropTypes.func,
+  footer: PropTypes.node,
+}
+
+Modal.defaultProps = {
+  onClose: undefined,
+  footer: null,
+}
+
+export default Modal

--- a/pages/cabinet/games.js
+++ b/pages/cabinet/games.js
@@ -4,6 +4,7 @@ import Head from 'next/head'
 import { useSession } from 'next-auth/react'
 
 import CabinetLayout from '@components/cabinet/CabinetLayout'
+import Modal from '@components/Modal'
 import getSessionSafe from '@helpers/getSessionSafe'
 import formatDate from '@helpers/formatDate'
 import formatDateTime from '@helpers/formatDateTime'
@@ -151,6 +152,7 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
   const [games, setGames] = useState(initialGames)
   const [persistedGames, setPersistedGames] = useState(initialGames)
   const [selectedGameId, setSelectedGameId] = useState(initialGames[0]?.id ?? null)
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [feedback, setFeedback] = useState(null)
 
@@ -167,6 +169,10 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
 
   useEffect(() => {
     setFeedback(null)
+  }, [selectedGameId])
+
+  useEffect(() => {
+    setIsEditModalOpen(false)
   }, [selectedGameId])
 
   const numberFormatter = useMemo(() => new Intl.NumberFormat('ru-RU'), [])
@@ -399,6 +405,22 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
     [canEditSelectedGame, updateSelectedGame]
   )
 
+  const handleOpenEditModal = useCallback(() => {
+    if (!canEditSelectedGame) {
+      return
+    }
+
+    setIsEditModalOpen(true)
+  }, [canEditSelectedGame])
+
+  const handleCloseEditModal = useCallback(() => {
+    if (isSaving) {
+      return
+    }
+
+    setIsEditModalOpen(false)
+  }, [isSaving])
+
   const tasksSummary = useMemo(() => {
     if (!selectedGame?.tasksStats) {
       return null
@@ -413,6 +435,116 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
       bonusLabel: bonus > 0 ? getNounBonusTasks(bonus) : null,
       canceledLabel: canceled > 0 ? `${canceled} отменено` : null,
     }
+  }, [selectedGame])
+
+  const gameTypeLabel = useMemo(() => {
+    if (!selectedGame) {
+      return '—'
+    }
+
+    const option = GAME_TYPE_OPTIONS.find((item) => item.value === selectedGame.type)
+    return option?.label ?? '—'
+  }, [selectedGame])
+
+  const plannedStartLabel = useMemo(() => {
+    if (!selectedGame?.dateStart) {
+      return 'Дата не назначена'
+    }
+
+    try {
+      return new Date(selectedGame.dateStart).toLocaleString('ru-RU', {
+        dateStyle: 'long',
+        timeStyle: 'short',
+      })
+    } catch (error) {
+      return 'Дата не назначена'
+    }
+  }, [selectedGame])
+
+  const taskDurationLabel = useMemo(() => {
+    if (!selectedGame) {
+      return '—'
+    }
+
+    const minutes = toMinutes(selectedGame.taskDuration)
+    return minutes > 0 ? `${minutes} мин` : 'Не задано'
+  }, [selectedGame])
+
+  const cluesDurationLabel = useMemo(() => {
+    if (!selectedGame) {
+      return '—'
+    }
+
+    const minutes = toMinutes(selectedGame.cluesDuration)
+    return minutes > 0 ? `${minutes} мин` : 'Подсказки отключены'
+  }, [selectedGame])
+
+  const clueModeDetails = useMemo(() => {
+    if (!selectedGame) {
+      return { modeLabel: '—', valueLabel: '—' }
+    }
+
+    const option = CLUE_EARLY_MODE_OPTIONS.find(
+      (item) => item.value === selectedGame.clueEarlyAccessMode
+    )
+    const minutes = toMinutes(selectedGame.clueEarlyPenalty)
+
+    if (selectedGame.clueEarlyAccessMode === 'penalty') {
+      return {
+        modeLabel: option?.label ?? '—',
+        valueLabel: minutes > 0 ? `Штраф ${minutes} мин` : 'Штраф не применяется',
+      }
+    }
+
+    return {
+      modeLabel: option?.label ?? '—',
+      valueLabel:
+        minutes > 0
+          ? `После подсказки добавляется ${minutes} мин ожидания`
+          : 'Без дополнительного времени',
+    }
+  }, [selectedGame])
+
+  const breakDurationLabel = useMemo(() => {
+    if (!selectedGame) {
+      return '—'
+    }
+
+    const minutes = toMinutes(selectedGame.breakDuration)
+    return minutes > 0 ? `${minutes} мин` : 'Без перерывов'
+  }, [selectedGame])
+
+  const taskFailurePenaltyLabel = useMemo(() => {
+    if (!selectedGame) {
+      return '—'
+    }
+
+    if (selectedGame.type === 'photo') {
+      const value = Number(selectedGame.taskFailurePenalty) || 0
+      return value > 0 ? `${value} баллов` : 'Штраф отсутствует'
+    }
+
+    const minutes = toMinutes(selectedGame.taskFailurePenalty)
+    return minutes > 0 ? `${minutes} мин` : 'Штраф отсутствует'
+  }, [selectedGame])
+
+  const manyCodesLimitLabel = useMemo(() => {
+    if (!selectedGame || selectedGame.type === 'photo') {
+      return null
+    }
+
+    const limit = Number(selectedGame.manyCodesPenalty?.[0]) || 0
+    return limit > 0 ? `${limit} попыток` : 'Лимит не задан'
+  }, [selectedGame])
+
+  const manyCodesPenaltyLabel = useMemo(() => {
+    if (!selectedGame || selectedGame.type === 'photo') {
+      return null
+    }
+
+    const seconds = Number(selectedGame.manyCodesPenalty?.[1]) || 0
+    const minutes = toMinutes(seconds)
+    return minutes > 0 ? `${minutes} мин` : 'Без штрафа'
   }, [selectedGame])
 
   const financesSummary = useMemo(() => {
@@ -513,26 +645,42 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
             {selectedGame ? (
               <div className="space-y-6">
                 <div className="p-5 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
-                  <div className="flex flex-wrap items-center gap-3">
-                    <span className="px-2.5 py-1 text-xs font-semibold text-primary bg-blue-50 rounded-full dark:bg-violet-500/20 dark:text-violet-100">
-                      {getGameStatusLabel(selectedGame.status)}
-                    </span>
-                    <span className="text-xs text-slate-500">
-                      Команд: {numberFormatter.format(selectedGame.teamsCount ?? 0)}
-                    </span>
-                    {selectedGame.updatedAt && (
-                      <span className="text-xs text-slate-500">
-                        Обновлено {formatRelativeTimeFromNow(selectedGame.updatedAt)}
-                      </span>
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-3">
+                        <span className="px-2.5 py-1 text-xs font-semibold text-primary bg-blue-50 rounded-full dark:bg-violet-500/20 dark:text-violet-100">
+                          {getGameStatusLabel(selectedGame.status)}
+                        </span>
+                        <span className="text-xs text-slate-500">
+                          Команд: {numberFormatter.format(selectedGame.teamsCount ?? 0)}
+                        </span>
+                        {selectedGame.updatedAt && (
+                          <span className="text-xs text-slate-500">
+                            Обновлено {formatRelativeTimeFromNow(selectedGame.updatedAt)}
+                          </span>
+                        )}
+                      </div>
+                      <h2 className="mt-4 text-xl font-semibold text-primary">
+                        {selectedGame.name || 'Без названия'}
+                      </h2>
+                      {tasksSummary && (
+                        <p className="mt-3 text-sm text-slate-600">
+                          {tasksSummary.totalLabel}
+                          {tasksSummary.bonusLabel ? ` · ${tasksSummary.bonusLabel}` : ''}
+                          {tasksSummary.canceledLabel ? ` · ${tasksSummary.canceledLabel}` : ''}
+                        </p>
+                      )}
+                    </div>
+                    {canEditSelectedGame && (
+                      <button
+                        type="button"
+                        onClick={handleOpenEditModal}
+                        className="inline-flex justify-center rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-blue-700"
+                      >
+                        Редактировать игру
+                      </button>
                     )}
                   </div>
-                  {tasksSummary && (
-                    <p className="mt-3 text-sm text-slate-600">
-                      {tasksSummary.totalLabel}
-                      {tasksSummary.bonusLabel ? ` · ${tasksSummary.bonusLabel}` : ''}
-                      {tasksSummary.canceledLabel ? ` · ${tasksSummary.canceledLabel}` : ''}
-                    </p>
-                  )}
                 </div>
 
                 {!location && (
@@ -559,7 +707,258 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                   </div>
                 )}
 
-                <fieldset disabled={!canEditSelectedGame} className="space-y-6 border-0 p-0 m-0">
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
+                  <h3 className="text-lg font-semibold text-primary">Общая информация</h3>
+                  {selectedGame.image && (
+                    <img
+                      src={selectedGame.image}
+                      alt="Обложка игры"
+                      className="mt-4 h-48 w-full rounded-xl object-cover"
+                    />
+                  )}
+                  <dl className="mt-4 grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Тип игры
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">{gameTypeLabel}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Плановое начало
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {plannedStartLabel}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Место старта
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {selectedGame.startingPlace || 'Не указано'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Финиш
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {selectedGame.finishingPlace || 'Не указан'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Индивидуальный старт
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {selectedGame.individualStart ? 'Да' : 'Нет'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Показывать организатора
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {selectedGame.showCreator ? 'Да' : 'Нет'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Публиковать задания в кабинете
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {selectedGame.showTasks ? 'Да' : 'Нет'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Скрывать результаты
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {selectedGame.hideResult ? 'Да' : 'Нет'}
+                      </dd>
+                    </div>
+                  </dl>
+                  {selectedGame.description && (
+                    <p className="mt-4 whitespace-pre-line text-sm text-slate-600 dark:text-slate-300">
+                      {selectedGame.description}
+                    </p>
+                  )}
+                </section>
+
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
+                  <h3 className="text-lg font-semibold text-primary">Параметры проведения</h3>
+                  <dl className="mt-4 grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Длительность задания
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">{taskDurationLabel}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Интервал подсказок
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">{cluesDurationLabel}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Режим досрочной подсказки
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {clueModeDetails.modeLabel}
+                        <br />
+                        <span className="text-xs text-slate-500">{clueModeDetails.valueLabel}</span>
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Перерыв между заданиями
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">{breakDurationLabel}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Штраф за невыполненное задание
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {taskFailurePenaltyLabel}
+                      </dd>
+                    </div>
+                    {manyCodesLimitLabel && (
+                      <div>
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                          Лимит неверных кодов
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                          {manyCodesLimitLabel}
+                        </dd>
+                      </div>
+                    )}
+                    {manyCodesPenaltyLabel && (
+                      <div>
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                          Штраф за превышение лимита
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                          {manyCodesPenaltyLabel}
+                        </dd>
+                      </div>
+                    )}
+                  </dl>
+                </section>
+
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
+                  <h3 className="text-lg font-semibold text-primary">Опции для капитана</h3>
+                  <ul className="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                    <li className="flex items-center gap-2">
+                      <span
+                        className={`h-2 w-2 rounded-full ${selectedGame.allowCaptainForceClue ? 'bg-emerald-500' : 'bg-slate-400'}`}
+                        aria-hidden="true"
+                      />
+                      <span>
+                        Капитан {selectedGame.allowCaptainForceClue ? 'может' : 'не может'} запрашивать подсказку
+                      </span>
+                    </li>
+                    <li className="flex items-center gap-2">
+                      <span
+                        className={`h-2 w-2 rounded-full ${selectedGame.allowCaptainFailTask ? 'bg-emerald-500' : 'bg-slate-400'}`}
+                        aria-hidden="true"
+                      />
+                      <span>
+                        Капитан {selectedGame.allowCaptainFailTask ? 'может' : 'не может'} провалить задание
+                      </span>
+                    </li>
+                    <li className="flex items-center gap-2">
+                      <span
+                        className={`h-2 w-2 rounded-full ${selectedGame.allowCaptainFinishBreak ? 'bg-emerald-500' : 'bg-slate-400'}`}
+                        aria-hidden="true"
+                      />
+                      <span>
+                        Капитан {selectedGame.allowCaptainFinishBreak ? 'может' : 'не может'} завершать перерыв
+                      </span>
+                    </li>
+                  </ul>
+                </section>
+
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
+                  <h3 className="text-lg font-semibold text-primary">Стоимость участия</h3>
+                  {selectedGame.prices?.length > 0 ? (
+                    <ul className="mt-4 space-y-3">
+                      {selectedGame.prices.map((price) => (
+                        <li
+                          key={price.id}
+                          className="flex items-center justify-between rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm dark:border-slate-700 dark:bg-slate-800/80"
+                        >
+                          <span className="text-slate-600 dark:text-slate-200">
+                            {price.name || 'Без названия'}
+                          </span>
+                          <span className="font-semibold text-primary">
+                            {currencyFormatter.format(Number(price.price) || 0)}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-4 text-sm text-slate-500">Стоимость участия не указана.</p>
+                  )}
+                </section>
+
+                <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
+                  <h3 className="text-lg font-semibold text-primary">Финансы</h3>
+                  <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-200">
+                    <p>
+                      Доходы: <span className="font-semibold">{currencyFormatter.format(financesSummary.income)}</span>
+                    </p>
+                    <p className="mt-1">
+                      Расходы: <span className="font-semibold">{currencyFormatter.format(financesSummary.expense)}</span>
+                    </p>
+                    <p className={`mt-1 font-semibold ${balanceClass}`}>
+                      Баланс: {currencyFormatter.format(financesSummary.balance)}
+                    </p>
+                  </div>
+                  {selectedGame.finances?.length > 0 ? (
+                    <ul className="mt-4 space-y-3">
+                      {selectedGame.finances.map((entry) => (
+                        <li
+                          key={entry.id}
+                          className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm dark:border-slate-700 dark:bg-slate-800/80"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-3">
+                            <span
+                              className={`text-xs font-semibold ${
+                                entry.type === 'expense' ? 'text-rose-600' : 'text-emerald-600'
+                              }`}
+                            >
+                              {entry.type === 'expense' ? 'Расход' : 'Доход'}
+                            </span>
+                            <span className="text-sm font-semibold text-primary">
+                              {currencyFormatter.format(Number(entry.sum) || 0)}
+                            </span>
+                          </div>
+                          <p className="mt-2 text-xs text-slate-500">
+                            {entry.date ? formatDate(entry.date) : 'Дата не указана'}
+                          </p>
+                          {entry.description ? (
+                            <p className="mt-2 whitespace-pre-line text-sm text-slate-600 dark:text-slate-300">
+                              {entry.description}
+                            </p>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-4 text-sm text-slate-500">Финансовые записи отсутствуют.</p>
+                  )}
+                </section>
+
+                <Modal
+                  isOpen={isEditModalOpen}
+                  title={`Редактирование игры «${selectedGame.name || 'Без названия'}»`}
+                  onClose={handleCloseEditModal}
+                >
+                <fieldset disabled={!canEditSelectedGame || isSaving} className="space-y-6 border-0 p-0 m-0">
                   <section className="p-6 bg-white dark:bg-slate-900/80 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm space-y-5">
                   <div className="grid gap-4 md:grid-cols-2">
                     <div>
@@ -1163,10 +1562,11 @@ const GamesPage = ({ initialGames, initialLocation, session: initialSession }) =
                     </button>
                   </div>
                 </fieldset>
+                </Modal>
               </div>
             ) : (
               <div className="flex items-center justify-center h-full p-6 bg-white dark:bg-slate-900/80 border border-dashed rounded-2xl border-slate-200 dark:border-slate-700">
-                <p className="text-sm text-slate-500">Выберите игру из списка слева, чтобы начать редактирование.</p>
+                <p className="text-sm text-slate-500">Выберите игру из списка слева, чтобы просмотреть детали.</p>
               </div>
             )}
           </div>

--- a/pages/cabinet/teams.js
+++ b/pages/cabinet/teams.js
@@ -4,6 +4,7 @@ import Head from 'next/head'
 import { useSession } from 'next-auth/react'
 
 import CabinetLayout from '@components/cabinet/CabinetLayout'
+import Modal from '@components/Modal'
 import getSessionSafe from '@helpers/getSessionSafe'
 import formatRelativeTimeFromNow from '@helpers/formatRelativeTimeFromNow'
 import getGameStatusLabel from '@helpers/getGameStatusLabel'
@@ -63,6 +64,7 @@ const TeamsPage = ({
   const [selectedTeamId, setSelectedTeamId] = useState(
     initialTeams[0]?.id ?? null
   )
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const [feedback, setFeedback] = useState(null)
   const [isSaving, setIsSaving] = useState(false)
   const [memberActionId, setMemberActionId] = useState(null)
@@ -82,6 +84,7 @@ const TeamsPage = ({
   useEffect(() => {
     setFeedback(null)
     setMemberActionId(null)
+    setIsEditModalOpen(false)
   }, [selectedTeamId])
 
   const selectedTeam = useMemo(
@@ -170,6 +173,22 @@ const TeamsPage = ({
     )
     setFeedback(null)
   }, [canManageSelectedTeam, persistedTeams, selectedTeamId])
+
+  const handleOpenEditModal = useCallback(() => {
+    if (!canManageSelectedTeam) {
+      return
+    }
+
+    setIsEditModalOpen(true)
+  }, [canManageSelectedTeam])
+
+  const handleCloseEditModal = useCallback(() => {
+    if (isSaving) {
+      return
+    }
+
+    setIsEditModalOpen(false)
+  }, [isSaving])
 
   const handleSaveTeam = useCallback(async () => {
     if (!selectedTeam || !location || !canManageSelectedTeam) {
@@ -507,29 +526,44 @@ const TeamsPage = ({
             {selectedTeam ? (
               <div className="space-y-6">
                 <div className="p-5 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl">
-                  <div className="flex flex-wrap items-center gap-3">
-                    <span
-                      className={`px-2.5 py-1 text-xs font-semibold rounded-full border ${
-                        selectedTeam.open
-                          ? 'text-emerald-600 bg-emerald-50 border-emerald-200'
-                          : 'text-slate-600 bg-slate-100 border-slate-200 dark:border-slate-700'
-                      }`}
-                    >
-                      {selectedTeam.open
-                        ? 'Открыта для заявок'
-                        : 'Закрытый состав'}
-                    </span>
-                    <span className="text-xs text-slate-500">
-                      Участников: {selectedTeam.membersCount ?? 0}
-                    </span>
-                    <span className="text-xs text-slate-500">
-                      Участвует в играх: {selectedTeam.gamesCount ?? 0}
-                    </span>
-                    {selectedTeam.updatedAt && (
-                      <span className="text-xs text-slate-500">
-                        Обновлено{' '}
-                        {formatRelativeTimeFromNow(selectedTeam.updatedAt)}
-                      </span>
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-3">
+                        <span
+                          className={`px-2.5 py-1 text-xs font-semibold rounded-full border ${
+                            selectedTeam.open
+                              ? 'text-emerald-600 bg-emerald-50 border-emerald-200'
+                              : 'text-slate-600 bg-slate-100 border-slate-200 dark:border-slate-700'
+                          }`}
+                        >
+                          {selectedTeam.open
+                            ? 'Открыта для заявок'
+                            : 'Закрытый состав'}
+                        </span>
+                        <span className="text-xs text-slate-500">
+                          Участников: {selectedTeam.membersCount ?? 0}
+                        </span>
+                        <span className="text-xs text-slate-500">
+                          Участвует в играх: {selectedTeam.gamesCount ?? 0}
+                        </span>
+                        {selectedTeam.updatedAt && (
+                          <span className="text-xs text-slate-500">
+                            Обновлено {formatRelativeTimeFromNow(selectedTeam.updatedAt)}
+                          </span>
+                        )}
+                      </div>
+                      <h2 className="mt-4 text-xl font-semibold text-primary">
+                        {selectedTeam.name || 'Без названия'}
+                      </h2>
+                    </div>
+                    {canManageSelectedTeam && (
+                      <button
+                        type="button"
+                        onClick={handleOpenEditModal}
+                        className="inline-flex justify-center rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-blue-700"
+                      >
+                        Редактировать команду
+                      </button>
                     )}
                   </div>
                 </div>
@@ -559,8 +593,154 @@ const TeamsPage = ({
                   </div>
                 )}
 
+                <section className="p-6 space-y-4 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl">
+                  <h3 className="text-lg font-semibold text-primary">Информация о команде</h3>
+                  <dl className="mt-3 grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Статус набора
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {selectedTeam.open ? 'Открыта для заявок' : 'Закрытый состав'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Участников
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {selectedTeam.membersCount ?? 0}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Участие в играх
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {selectedTeam.gamesCount ?? 0}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Капитан
+                      </dt>
+                      <dd className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                        {selectedTeam.captain?.name || 'Не назначен'}
+                        {selectedTeam.captain?.username
+                          ? ` (@${selectedTeam.captain.username})`
+                          : ''}
+                      </dd>
+                    </div>
+                  </dl>
+                  {selectedTeam.description ? (
+                    <p className="mt-3 whitespace-pre-line text-sm text-slate-600 dark:text-slate-300">
+                      {selectedTeam.description}
+                    </p>
+                  ) : (
+                    <p className="mt-3 text-sm text-slate-500">
+                      Описание команды пока не заполнено.
+                    </p>
+                  )}
+                </section>
+
+                <section className="p-6 space-y-4 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-lg font-semibold text-primary">Состав команды</h3>
+                    {selectedTeam.captain && (
+                      <span className="text-xs text-slate-500">
+                        Капитан: {selectedTeam.captain.name || 'не указан'}
+                      </span>
+                    )}
+                  </div>
+                  {selectedTeam.members?.length > 0 ? (
+                    <div className="space-y-3">
+                      {selectedTeam.members.map((member) => {
+                        const phoneLink = normalizePhoneLink(member.phone)
+
+                        return (
+                          <div
+                            key={member.id}
+                            className="p-4 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl"
+                          >
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                              <div>
+                                <p className="text-sm font-semibold text-primary">
+                                  {member.name || 'Без имени'}
+                                  {member.isCaptain ? ' · Капитан' : ''}
+                                </p>
+                                {member.username && (
+                                  <p className="mt-1 text-xs text-slate-500">@{member.username}</p>
+                                )}
+                                {member.userRole && (
+                                  <p className="mt-1 text-xs text-slate-400">
+                                    Роль в системе: {member.userRole}
+                                  </p>
+                                )}
+                              </div>
+                              <div className="text-right">
+                                {member.phone && (
+                                  <a
+                                    href={phoneLink ? `tel:${phoneLink}` : undefined}
+                                    className="block text-xs text-primary hover:underline"
+                                  >
+                                    {member.phone}
+                                  </a>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-500">
+                      Пока нет участников. Пригласите игроков через телеграм-бота, чтобы они появились здесь.
+                    </p>
+                  )}
+                </section>
+
+                <section className="p-6 space-y-4 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl">
+                  <h3 className="text-lg font-semibold text-primary">Игры команды</h3>
+                  {selectedTeam.games?.length > 0 ? (
+                    <ul className="space-y-3">
+                      {selectedTeam.games.map((game) => (
+                        <li
+                          key={game.id}
+                          className="p-4 border border-slate-200 dark:border-slate-700 rounded-2xl bg-slate-50 dark:bg-slate-800/80"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-3">
+                            <p className="text-sm font-semibold text-primary">
+                              {game.name || 'Без названия'}
+                            </p>
+                            <span className="text-xs text-slate-500">
+                              {getGameStatusLabel(game.status)}
+                            </span>
+                          </div>
+                          <p className="mt-2 text-xs text-slate-500">
+                            {game.dateStart
+                              ? new Date(game.dateStart).toLocaleString('ru-RU', {
+                                  dateStyle: 'short',
+                                  timeStyle: 'short',
+                                })
+                              : 'Дата не назначена'}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-slate-500">
+                      Команда пока не участвовала в играх.
+                    </p>
+                  )}
+                </section>
+
+                <Modal
+                  isOpen={isEditModalOpen}
+                  title={`Редактирование команды «${selectedTeam.name || 'Без названия'}»`}
+                  onClose={handleCloseEditModal}
+                >
                 <fieldset
-                  disabled={!canManageSelectedTeam}
+                  disabled={!canManageSelectedTeam || isSaving}
                   className="p-0 m-0 space-y-6 border-0"
                 >
                   <section className="p-6 space-y-5 bg-white dark:bg-slate-900/80 border shadow-sm border-slate-200 dark:border-slate-700 rounded-2xl">
@@ -811,6 +991,7 @@ const TeamsPage = ({
                     </button>
                   </div>
                 </fieldset>
+                </Modal>
               </div>
             ) : (
               <div className="flex items-center justify-center h-full p-6 bg-white dark:bg-slate-900/80 border border-dashed border-slate-200 dark:border-slate-700 rounded-2xl">


### PR DESCRIPTION
## Summary
- add a reusable modal component for cabinet screens
- replace inline game and team editors with read-only details and an edit button that opens the existing form in a modal
- keep role-based access to editing actions for games and teams

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe03f10180832992f51616236f4b8e