### PR TITLE
Fix undefined isPhotoGame flag in GameEditModal

### DIFF
--- a/components/modals/GameEditModal.js
+++ b/components/modals/GameEditModal.js
@@ -74,8 +74,11 @@ const GameEditModal = ({
   taskFailurePenaltyLabel,
   manyCodesLimitLabel,
   manyCodesPenaltyLabel,
-}) => (
-  <Modal
+}) => {
+  const isPhotoGame = selectedGame?.type === 'photo'
+
+  return (
+    <Modal
                     isOpen={isEditModalOpen}
                     title={`Редактирование игры «${selectedGame.name || 'Без названия'}»`}
                     onClose={handleCloseEditModal}
@@ -1441,7 +1444,8 @@ const GameEditModal = ({
                     </div>
                   </fieldset>
                   </Modal>
-)
+  )
+}
 
 GameEditModal.propTypes = {
   selectedGame: PropTypes.shape({ id: PropTypes.string }).isRequired,


### PR DESCRIPTION
## Summary
- define the `isPhotoGame` flag based on the selected game type before rendering the edit modal
- prevent the modal from crashing when rendering photo game subtasks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905d5a579008329a66433979ea74d97